### PR TITLE
fix: Expose middleware pipeline

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,9 @@
                 "${fileBasenameNoExtension}",
                 "--runInBand",
                 "--config",
-                "jest.config.debug.js"
+                "jest.config.debug.js",
+                "--testTimeout",
+                "1000000"
             ],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -2,8 +2,8 @@ import { Context } from "koa"
 import ptr from "path-to-regexp"
 import { useCache } from "tinspector"
 
-import { Configuration, Middleware, MiddlewareUtil, RouteContext, RouteInfo, ValidationError, HttpStatusError } from "./types"
-import { ActionInvocation, NotFoundActionInvocation, pipe } from "./middleware-pipeline"
+import {  pipe } from "./middleware-pipeline"
+import { HttpStatusError, Configuration, Middleware, MiddlewareUtil, RouteContext, RouteInfo, ValidationError } from "./types"
 
 // --------------------------------------------------------------------- //
 // ------------------------------- TYPES ------------------------------- //
@@ -35,18 +35,6 @@ function getMatcher(infos: RouteInfo[], ctx: Context) {
     return infos.map(x => toRegExp(x, ctx.path)).find(x => Boolean(x.match) && x.method == ctx.method)
 }
 
-function getMiddleware(global: Middleware[], route: RouteInfo) {
-    const conMdws = MiddlewareUtil.extractDecorators(route)
-    const result: Middleware[] = []
-    for (const mdw of global) {
-        result.push(mdw)
-    }
-    for (const mdw of conMdws) {
-        result.push(mdw)
-    }
-    return result
-}
-
 function sendError(ctx: Context, status: number, message: any) {
     ctx.status = status
     ctx.body = { status, message }
@@ -56,13 +44,12 @@ function sendError(ctx: Context, status: number, message: any) {
 /* ------------------------------- ROUTER ---------------------------------------- */
 /* ------------------------------------------------------------------------------- */
 
-function router(infos: RouteInfo[], globalMiddleware: Middleware[]) {
+function router(infos: RouteInfo[], config:Configuration) {
     const matchCache = new Map<string, RouteMatcher | undefined>()
-    const middlewareCache = new Map<string, Middleware[]>()
     const getMatcherCached = useCache(matchCache, getMatcher, (info, ctx) => `${ctx.method}${ctx.path}`)
-    const getMiddlewareCached = useCache(middlewareCache, getMiddleware, (global, route) => route.url)
     return async (ctx: Context) => {
         try {
+            ctx.config = config
             const match = getMatcherCached(infos, ctx)
             if (match) {
                 for (const key in match.query) {
@@ -70,12 +57,9 @@ function router(infos: RouteInfo[], globalMiddleware: Middleware[]) {
                     ctx.request.query[key] = element
                 }
                 ctx.route = match.route
-                const middlewares = getMiddlewareCached(globalMiddleware, match.route)
-                await pipe(middlewares, ctx, new ActionInvocation(<RouteContext>ctx))
             }
-            else {
-                await pipe(globalMiddleware.slice(0), ctx, new NotFoundActionInvocation(ctx))
-            }
+            const result = await pipe(ctx, ctx.route)
+            await result.execute(ctx)
         }
         catch (e) {
             if (e instanceof ValidationError) 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -111,7 +111,6 @@ declare module "koa" {
     }
 }
 
-
 export interface RouteContext extends Context {
     route: Readonly<RouteInfo>,
     parameters: any[]
@@ -311,6 +310,11 @@ export interface Configuration {
     mode: "debug" | "production"
 
     /**
+     * List of registered global middlewares
+     */
+    middlewares:Middleware[]
+
+    /**
      * Specify controller path (absolute or relative to entry point) or the controller classes array.
      */
     controller: string | Class[] | Class
@@ -347,7 +351,6 @@ export interface Configuration {
 }
 
 export interface PlumierConfiguration extends Configuration {
-    middleware: Middleware[]
     facilities: Facility[]
 }
 

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -106,11 +106,10 @@ async function validate(ctx: Context): Promise<tc.Result> {
 // --------------------------------------------------------------------- //
 
 class ValidationMiddleware implements Middleware {
-    constructor(private config: Configuration) { }
+    constructor() { }
 
     async execute(invocation: Readonly<Invocation>): Promise<ActionResult> {
         const ctx = invocation.context;
-        (ctx as any).config = this.config
         if (!ctx.route) return invocation.proceed();
         const result = await validate(invocation.context);
         if (result.issues)

--- a/packages/plumier/src/application.ts
+++ b/packages/plumier/src/application.ts
@@ -25,30 +25,28 @@ class DefaultDependencyResolver implements DependencyResolver {
     }
 }
 
-const DefaultConfiguration: Configuration = {
-    mode: "debug",
-    controller: "./controller",
-    dependencyResolver: new DefaultDependencyResolver()
-}
-
 export class Plumier implements PlumierApplication {
     readonly config: Readonly<PlumierConfiguration>;
     readonly koa: Koa
-    private globalMiddleware: Middleware[] = []
 
     constructor() {
         this.koa = new Koa()
-        this.config = { ...DefaultConfiguration, middleware: [], facilities: [] }
+        this.config = {
+            mode: "debug",
+            controller: "./controller",
+            dependencyResolver: new DefaultDependencyResolver(),
+            middlewares: [], facilities: []
+        }
     }
 
     use(option: KoaMiddleware): Application
     use(option: Middleware): Application
     use(option: KoaMiddleware | Middleware): Application {
         if (typeof option === "function") {
-            this.globalMiddleware.push(MiddlewareUtil.fromKoa(option))
+            this.config.middlewares.push(MiddlewareUtil.fromKoa(option))
         }
         else {
-            this.globalMiddleware.push(option)
+            this.config.middlewares.push(option)
         }
         return this
     }
@@ -76,7 +74,7 @@ export class Plumier implements PlumierApplication {
                 await facility.initialize(this, routes)
             }
             if (this.config.mode === "debug") printAnalysis(analyzeRoutes(routes, this.config.analyzers))
-            this.koa.use(router(routes, this.globalMiddleware))
+            this.koa.use(router(routes, this.config))
             return this.koa
         }
         catch (e) {

--- a/packages/plumier/src/facility.ts
+++ b/packages/plumier/src/facility.ts
@@ -35,7 +35,7 @@ export class WebApiFacility extends DefaultFacility {
             app.set({ controller: this.opt.controller })
         if (this.opt && this.opt.validators)
             app.set({ validators: this.opt.validators })
-        app.use(new ValidationMiddleware(app.config))
+        app.use(new ValidationMiddleware())
     }
 }
 


### PR DESCRIPTION
## Middleware Pipeline

Middleware pipeline now possible to call from inside the middleware itself. This feature useful when it is required to invoke specific controller's action from inside middleware. 

Signature 

```typescript
function pipe(ctx: Context, route?: RouteInfo, state?: any)
```

* `ctx` current request context
* `route` route infor that the action will be executed 
* `state` additional state added to the `ctx.state` property to prevent infinite call.

example: 

```typescript
class AnimalFacility extends DefaultFacility {
    async initialize(app: Readonly<PlumierApplication>, routes: RouteInfo[]): Promise<void> {
        app.use({
            execute: async i => {
                if (!i.context.state.isFallback && i.context.request.path === "/hello")
                    return await pipe(i.context, routes[0], { isFallback: true })
                else
                    return i.proceed()
            }
        })
    }
}
```