### PR TITLE
feat: Controller invoker

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@ import { val } from "typedconverter"
 export { val }
 export { AuthorizeCallback, AuthorizeMiddleware, RoleField, updateRouteAccess } from "./authorization";
 export { HeaderPart, RequestPart, BindingDecorator, binder } from "./binder";
-export { pipe } from "./middleware-pipeline";
+export { invoke } from "./middleware-pipeline";
 export { response } from "./response";
 export { analyzeRoutes, generateRoutes, printAnalysis } from "./route-generator";
 export { router } from "./router";

--- a/packages/core/src/middleware-pipeline.ts
+++ b/packages/core/src/middleware-pipeline.ts
@@ -50,9 +50,9 @@ class ActionInvocation implements Invocation {
     }
 }
 
-function pipe(ctx: Context, route?: RouteInfo, state?: any) {
+function pipe(ctx: Context, route?: RouteInfo, caller:string = "system") {
     const context = ctx;
-    context.state = { ...ctx.state, ...state }
+    context.state.caller = caller
     let middlewares: Middleware[];
     let invocationStack: Invocation;
     if (!!route) {
@@ -70,4 +70,8 @@ function pipe(ctx: Context, route?: RouteInfo, state?: any) {
     return invocationStack.proceed()
 }
 
-export { pipe };
+function invoke(ctx: Context, route: RouteInfo){
+    return pipe(ctx, route, "invoke")
+}
+
+export { invoke, pipe };

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -50,6 +50,7 @@ function router(infos: RouteInfo[], config:Configuration) {
     return async (ctx: Context) => {
         try {
             ctx.config = config
+            ctx.routes = infos
             const match = getMatcherCached(infos, ctx)
             if (match) {
                 for (const key in match.query) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -106,6 +106,7 @@ export interface Invocation {
 declare module "koa" {
     interface Context {
         route?: Readonly<RouteInfo>,
+        routes: RouteInfo[]
         config: Readonly<Configuration>,
         parameters?: any[]
     }


### PR DESCRIPTION
## Controller Invoker

Sometime its necessary to get the result of another controller including its middleware execution, from inside another controller or from a middleware. The real case for this function is create a redirect request without changing the URL.

Controller invoker execute the middleware pipeline to execute controller including its middleware, its returned `ActionResult` so it can be returned from inside the calling controller or middleware. 

### Signature 

```typescript
function invoke(ctx: Context, route: RouteInfo)
```

Parameters: 
* `ctx` the request context 
* `route` route info metadata of the controller will be invoked, route metadata information can be retrieved from `ctx.routes`

### Context State 
When called from inside middleware its necessary to check the context state to prevent infinite call loop. Plumier provide `ctx.state.caller` property which possibly contains value: 
* `system` mean the request called by the Plumier request system.
* `invoke` mean the request called by controller invoker.

### Example Usage
Invoke another controller from inside controller 
```typescript
class AnimalController {
    get() {
        return { method: "get" }
    }

    list(@bind.ctx() ctx:Context){
        //invoke the AnimalController.get 
        return invoke(ctx, ctx.routes.find(x => x.action.name === "get")!)
    }
}
```

Invoke another controller from inside middleware 

```typescript
class AnimalMiddleware implements Middleware {
    execute(i: Readonly<Invocation>): Promise<ActionResult> {
        //make sure to check the context state property
        //only invoke another controller if the state is "system"
        if (i.context.state.caller === "system" && i.context.request.path === "/hello")
                //assume that it execute the first controller's action
                return invoke(i.context, i.context.routes[0])
            else
                return i.proceed()
    }
}
```

Above middleware will create a new route `/hello` that will execute the first controller's action registered in Plumier system.


