### PR TITLE
fix: Expose binder name on BindingDecorator

### DIFF
--- a/packages/core/src/binder.ts
+++ b/packages/core/src/binder.ts
@@ -8,9 +8,7 @@ import { isCustomClass } from "./common"
 // ------------------------------- TYPES ------------------------------- //
 // --------------------------------------------------------------------- // 
 
-type BinderName = "ctx" | "cookie" | "header" | "body" | "request" | "query" | "user" | "cookie"
-
-interface BindingDecorator { type: "ParameterBinding", process: (ctx: Context) => any, name:BinderName }
+interface BindingDecorator { type: "ParameterBinding", process: (ctx: Context) => any, name:string }
 type RequestPart = keyof Request
 type HeaderPart = keyof IncomingHttpHeaders
 
@@ -55,4 +53,4 @@ function chain(...binder: Binder[]) {
 
 const binder = chain(bindDecorator, bindByName, bindBody)
 
-export { RequestPart, HeaderPart, BindingDecorator, binder, BinderName }
+export { RequestPart, HeaderPart, BindingDecorator, binder }

--- a/packages/core/src/binder.ts
+++ b/packages/core/src/binder.ts
@@ -8,7 +8,9 @@ import { isCustomClass } from "./common"
 // ------------------------------- TYPES ------------------------------- //
 // --------------------------------------------------------------------- // 
 
-interface BindingDecorator { type: "ParameterBinding", process: (ctx: Context) => any }
+type BinderName = "ctx" | "cookie" | "header" | "body" | "request" | "query" | "user" | "cookie"
+
+interface BindingDecorator { type: "ParameterBinding", process: (ctx: Context) => any, name:BinderName }
 type RequestPart = keyof Request
 type HeaderPart = keyof IncomingHttpHeaders
 
@@ -53,4 +55,4 @@ function chain(...binder: Binder[]) {
 
 const binder = chain(bindDecorator, bindByName, bindBody)
 
-export { RequestPart, HeaderPart, BindingDecorator, binder }
+export { RequestPart, HeaderPart, BindingDecorator, binder, BinderName }

--- a/packages/core/src/decorator.bind.ts
+++ b/packages/core/src/decorator.bind.ts
@@ -1,7 +1,7 @@
 import { Context } from "koa"
 import { decorateParameter, mergeDecorator } from "tinspector"
 
-import { BindingDecorator, HeaderPart, RequestPart, BinderName } from "./binder"
+import { BindingDecorator, HeaderPart, RequestPart } from "./binder"
 import { getChildValue } from "./common"
 import { val } from '.';
 import { GetOption } from 'cookies';
@@ -9,7 +9,7 @@ import { GetOption } from 'cookies';
 
 export namespace bind {
 
-    function ctxDecorator(name: BinderName, part?: string) {
+    function ctxDecorator(name: string, part?: string) {
         return custom(ctx => part ? getChildValue(ctx, part) : ctx, name)
     }
 

--- a/packages/core/src/decorator.bind.ts
+++ b/packages/core/src/decorator.bind.ts
@@ -1,15 +1,16 @@
 import { Context } from "koa"
 import { decorateParameter, mergeDecorator } from "tinspector"
 
-import { BindingDecorator, HeaderPart, RequestPart } from "./binder"
+import { BindingDecorator, HeaderPart, RequestPart, BinderName } from "./binder"
 import { getChildValue } from "./common"
 import { val } from '.';
 import { GetOption } from 'cookies';
 
+
 export namespace bind {
 
-    function ctxDecorator(part?: string) {
-        return custom(ctx => part ? getChildValue(ctx, part) : ctx)
+    function ctxDecorator(name: BinderName, part?: string) {
+        return custom(ctx => part ? getChildValue(ctx, part) : ctx, name)
     }
 
     /**
@@ -26,7 +27,7 @@ export namespace bind {
      * @param part part of context, use dot separator to access child property
      */
     export function ctx(part?: string) {
-        return ctxDecorator(part)
+        return ctxDecorator("ctx", part)
     }
 
     /**
@@ -42,7 +43,7 @@ export namespace bind {
      * @param part part of request ex: body, method, query etc
      */
     export function request(part?: RequestPart) {
-        return ctxDecorator(["request", part].join("."))
+        return ctxDecorator("request", ["request", part].join("."))
     }
 
     /**
@@ -56,7 +57,7 @@ export namespace bind {
      *     method(@bind.body("age") age:number){}
      */
     export function body(part?: string) {
-        return ctxDecorator(["request", "body", part].join("."))
+        return ctxDecorator("body", ["request", "body", part].join("."))
     }
 
     /**
@@ -70,7 +71,7 @@ export namespace bind {
      *     method(@bind.header("cookie") age:any){}
      */
     export function header(key?: HeaderPart) {
-        return ctxDecorator(["request", "headers", key].join("."))
+        return ctxDecorator("header", ["request", "headers", key].join("."))
     }
 
     /**
@@ -84,7 +85,7 @@ export namespace bind {
      *     method(@bind.query("type") type:string){}
      */
     export function query(name?: string) {
-        return ctxDecorator(["request", "query", name].join("."))
+        return ctxDecorator("query", ["request", "query", name].join("."))
     }
 
     /**
@@ -93,7 +94,7 @@ export namespace bind {
      *     method(@bind.user() user:User){}
      */
     export function user() {
-        return mergeDecorator(val.optional(), ctxDecorator("state.user"))
+        return mergeDecorator(val.optional(), ctxDecorator("user", "state.user"))
     }
 
     /**
@@ -102,7 +103,7 @@ export namespace bind {
      *     method(@bind.cookie("name") cookie:string){}
      */
     export function cookie(name: string, opt?: GetOption) {
-        return mergeDecorator(val.optional(), bind.custom(ctx => ctx.cookies.get(name, opt)))
+        return mergeDecorator(val.optional(), bind.custom(ctx => ctx.cookies.get(name, opt), "cookie"))
     }
 
     /**
@@ -124,8 +125,8 @@ export namespace bind {
      * 
      * @param process callback function to process the Koa context
      */
-    export function custom(process: (ctx: Context) => any) {
-        return decorateParameter(<BindingDecorator>{ type: "ParameterBinding", process })
+    export function custom(process: (ctx: Context) => any, name: string = "custom") {
+        return decorateParameter(<BindingDecorator>{ type: "ParameterBinding", process, name })
     }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 import { val } from "typedconverter"
 export { val }
 export { AuthorizeCallback, AuthorizeMiddleware, RoleField, updateRouteAccess } from "./authorization";
-export { HeaderPart, RequestPart, BindingDecorator, binder } from "./binder";
+export { HeaderPart, RequestPart, BindingDecorator, binder, BinderName } from "./binder";
 export { invoke } from "./middleware-pipeline";
 export { response } from "./response";
 export { analyzeRoutes, generateRoutes, printAnalysis } from "./route-generator";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 import { val } from "typedconverter"
 export { val }
 export { AuthorizeCallback, AuthorizeMiddleware, RoleField, updateRouteAccess } from "./authorization";
-export { HeaderPart, RequestPart, BindingDecorator, binder, BinderName } from "./binder";
+export { HeaderPart, RequestPart, BindingDecorator, binder } from "./binder";
 export { invoke } from "./middleware-pipeline";
 export { response } from "./response";
 export { analyzeRoutes, generateRoutes, printAnalysis } from "./route-generator";

--- a/packages/plumier/test/integration/binder/binder.spec.ts
+++ b/packages/plumier/test/integration/binder/binder.spec.ts
@@ -565,6 +565,16 @@ describe("Parameter Binding", () => {
         //     const meta = reflect(AnimalController)
         //     expect(skipValidation(meta.methods[0].parameters[0].decorators)).toBe(true)
         // })
+
+        it("Should has appropriate name", async () => {
+            class AnimalController {
+                @route.get()
+                get(@bind.request() b: Request) {
+                }
+            }
+            const meta = reflect(AnimalController)
+            expect(meta.methods[0].parameters[0].decorators[0].name).toBe("request")
+        })
     })
 
     describe("Request body parameter binding", () => {
@@ -642,6 +652,16 @@ describe("Parameter Binding", () => {
         //     const meta = reflect(AnimalController)
         //     expect(skipValidation(meta.methods[0].parameters[0].decorators)).toBe(false)
         // })
+
+        it("Should has appropriate name", async () => {
+            class AnimalController {
+                @route.post()
+                get(@bind.body() b: any) {
+                }
+            }
+            const meta = reflect(AnimalController)
+            expect(meta.methods[0].parameters[0].decorators[0].name).toBe("body")
+        })
     })
 
     describe("Request header parameter binding", () => {
@@ -700,6 +720,16 @@ describe("Parameter Binding", () => {
                 .post("/animal/save")
                 .send({})
                 .expect(422, { status: 422, message: [{ "path": ["b"], "messages": [`Unable to convert "[object Object]" into Number`] }] })
+        })
+
+        it("Should has appropriate name", async () => {
+            class AnimalController {
+                @route.get()
+                get(@bind.header("ip") b: string) {
+                }
+            }
+            const meta = reflect(AnimalController)
+            expect(meta.methods[0].parameters[0].decorators[0].name).toBe("header")
         })
     })
 
@@ -789,6 +819,16 @@ describe("Parameter Binding", () => {
                 .get("/animal/get?id=747474&name=Mimi&deceased=ON&birthday=2018-1-1")
                 .expect(422, { status: 422, message: [{ "path": ["b"], "messages": [`Unable to convert "[object Object]" into Number`] }] })
         })
+
+        it("Should has appropriate name", async () => {
+            class AnimalController {
+                @route.get()
+                get(@bind.query() b: any) {
+                }
+            }
+            const meta = reflect(AnimalController)
+            expect(meta.methods[0].parameters[0].decorators[0].name).toBe("query")
+        })
     })
 
     describe("Context parameter binding", () => {
@@ -845,6 +885,16 @@ describe("Parameter Binding", () => {
                 .post("/animal/get")
                 .send([{ id: '747474', name: 'Mimi', deceased: 'ON', birthday: '2018-1-1' }])
                 .expect(200, { id: 747474, name: "Mimi", deceased: true, birthday: new Date("2018-1-1").toISOString() })
+        })
+
+        it("Should has appropriate name", async () => {
+            class AnimalController {
+                @route.get()
+                get(@bind.ctx() b: any) {
+                }
+            }
+            const meta = reflect(AnimalController)
+            expect(meta.methods[0].parameters[0].decorators[0].name).toBe("ctx")
         })
     })
 
@@ -905,6 +955,16 @@ describe("Parameter Binding", () => {
             await Supertest(app.callback())
                 .get("/animal/get")
                 .expect(403)
+        })
+
+        it("Should has appropriate name", async () => {
+            class AnimalController {
+                @route.get()
+                get(@bind.user() b: any) {
+                }
+            }
+            const meta = reflect(AnimalController)
+            expect(meta.methods[0].parameters[0].decorators[1].name).toBe("user")
         })
     })
 


### PR DESCRIPTION
## Exposed Parameter Binding Name
This PR expose name of each parameter binding decorator. Previously it was impossible to identify which decorator was a parameter applied. 

### Example Usage

```typescript
class AnimalController {
    @route.get()
    get(@bind.header("ip") ip: string) {
    }
}
const meta = reflect(AnimalController)
console.log(meta.methods[0].parameters[0].decorators[0])
```

The result : 

```
{ type: 'ParameterBinding', process: [Function], name: 'header' }
```

Its now possible to distinguish between `@bind.header()`, `@bind.body()`, `@bind.cookie()` etc from its `name` property. 
