### PR TITLE
fix: Allow sync or async callback function on custom authorization

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,4 +1,4 @@
-name: CI
+name: canary
 
 on:
   push:

--- a/docs/extends/Custom-Authorization.md
+++ b/docs/extends/Custom-Authorization.md
@@ -28,7 +28,7 @@ export class AnimalController {
 `@authorize.custom` receive two parameters a callback which will evaluate user authorization and `tag` metadata that will be used for further metadata processing. The callback signature is like below
 
 ```typescript
-(info: AuthorizeMetadataInfo, location: "Class" | "Parameter" | "Method") => Promise<boolean>
+(info: AuthorizeMetadataInfo, location: "Class" | "Parameter" | "Method") => boolean | Promise<boolean>
 ```
 
 * `info` Metadata information about current authorization.
@@ -41,8 +41,6 @@ export interface AuthorizeMetadataInfo {
     role: string[]
     user:any
     ctx: Koa.Context
-    route: RouteInfo
-    parameters: any[]
     value?: any
 }
 ```
@@ -50,8 +48,6 @@ export interface AuthorizeMetadataInfo {
 * `role` is roles of current login user, single or multiple role
 * `user` Current login user
 * `ctx` Koa context of current request
-* `route` Information about current route, contains metadata information about controller and action
-* `parameters` List of parameters that will be used to execute the action
 * `value` optional, value of current parameter (if authorization applied into parameter)
 
 
@@ -86,10 +82,10 @@ Action `modify` above will only authorized to `Admin` or if the login user has t
 
 ```typescript
 export function isAdminOrOwner() {
-    return authorize.custom(async (info, position) => {
-        const {role, user, parameters} = info
+    return authorize.custom((info, position) => {
+        const {role, user, ctx} = info
         //the first parameter MUST be the ID of the requested user
-        const id = parameters[0]
+        const id = ctx.parameters[0]
         return role.some(x => x === "Admin") || user.id === id
     })
 }

--- a/packages/core/src/authorization.ts
+++ b/packages/core/src/authorization.ts
@@ -8,11 +8,11 @@ import { ActionResult, HttpStatusError, Invocation, Middleware, RouteInfo, Autho
 // ------------------------------- TYPES ------------------------------- //
 // --------------------------------------------------------------------- //
 
-type AuthorizeCallback = (info: AuthorizeMetadataInfo, location: "Class" | "Parameter" | "Method") => Promise<boolean>
+type AuthorizeCallback = (info: AuthorizeMetadataInfo, location: "Class" | "Parameter" | "Method") => boolean | Promise<boolean>
 
 interface AuthorizeDecorator {
     type: "plumier-meta:authorize",
-    authorize: string | ((info: AuthorizeMetadataInfo) => Promise<boolean>),
+    authorize: string | ((info: AuthorizeMetadataInfo) => boolean | Promise<boolean>),
     tag: string
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -277,15 +277,13 @@ export type ValidatorStore = { [key: string]: ValidatorFunction }
 // --------------------------------------------------------------------- //
 
 
-export type AuthorizeStore = { [key: string]: (info: AuthorizeMetadataInfo) => Promise<boolean> }
+export type AuthorizeStore = { [key: string]: (info: AuthorizeMetadataInfo) => boolean | Promise<boolean> }
 
 export interface AuthorizeMetadataInfo {
+    value?: any
     role: string[]
     user: any
     ctx: RouteContext
-    route: RouteInfo
-    parameters: any[]
-    value?: any
 }
 
 


### PR DESCRIPTION
## Sync or Async calb
This PR contains fix that allows sync and async callback function on custom authorization.

### Sync Callback Function
Can be used for simple authorization.

```typescript 
@authorize.custom(x => x.user.userId === 1234)
```

### Async Callback Function 
Useful when the callback function need to do some long running operation such as database call etc. 

```typescript 
@authorize.custom(async x => {
      const user = await UserModel.findById(x.user.userId)
      return user.active && x.user.role === "User"
})
```