### PR TITLE
fix: Allow sync or async callback function on custom validator

### DIFF
--- a/docs/extends/Custom-Validator.md
+++ b/docs/extends/Custom-Validator.md
@@ -57,8 +57,9 @@ Sometime its not possible to validate value only on single property, but require
 
 ```typescript
 function checkConfirmPassword() {
-    return val.custom(async (x, info) => {
-        return x.password !== x.confirmPassword ? [{ path: "confirmPassword", messages: ["Password is not the same"] }] : undefined
+    return val.custom((x, info) => {
+        if(x.password !== x.confirmPassword)
+            return val.result("confirmPassword", "Password is not the same") 
     })
 }
 

--- a/docs/extends/Custom-Validator.md
+++ b/docs/extends/Custom-Validator.md
@@ -6,7 +6,7 @@ title: Custom Validator
 Custom validator can be created using `@val.custom` decorator, you can wrap the `@val.custom` inside a function and make a new validator decorator, and provide logic on the Validator function callback. Validator function signature is like below:
 
 ```typescript 
-(value: string, info: ValidatorInfo) => Promise<AsyncValidatorResult[] | string | undefined>
+(value: string, info: ValidatorInfo) => string | AsyncValidatorResult[] | undefined | Promise<AsyncValidatorResult[] | string | undefined>
 ```
 
 * `value` is the current value that will be validated. value will always of type string
@@ -18,14 +18,12 @@ Signature of the `ValidatorInfo` is like below
 ```typescript
 interface ValidatorInfo {
     name: string,
-    route: RouteInfo,
     ctx: Context,
     parent?: { type: Class, decorators: any[] }
 }
 ```
 
 * `name` name of the current validating property or parameter 
-* `route` route information, contains metadata information of current route 
 * `ctx` Koa context of current request 
 * `parent` parent class of current validation property, can be `undefined` if the current validating is a method parameter
 
@@ -36,7 +34,7 @@ For example we will create an age restriction validator which restrict only 18+ 
 import { val } from "@plumier/validator";
 
 export async function is18plus(){
-    return val.custom(async val => parseInt(val) < 18 : "Should greater than 18 years old" : undefined)
+    return val.custom(val => parseInt(val) < 18 : "Should greater than 18 years old" : undefined)
 }
 ```
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,10 +3,10 @@ module.exports = {
   testEnvironment: 'node',
   silent: false,
   verbose: false,
-  collectCoverage: true,
-  collectCoverageFrom: [
-    "packages/*/src/*"
-  ],
+  // collectCoverage: true,
+  // collectCoverageFrom: [
+  //   "packages/*/src/*"
+  // ],
   coverageThreshold: {
     global: {
       branches: 100,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
     "path-to-regexp": "^3.1.0",
     "tinspector": "^2.2.7",
     "tslib": "^1.10.0",
-    "typedconverter": "^1.0.4"
+    "typedconverter": "^1.0.5"
   },
   "bugs": {
     "url": "https://github.com/plumier/plumier/issues"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -257,8 +257,7 @@ export interface ValidatorDecorator {
 
 export interface ValidatorInfo {
     name: string,
-    route: RouteInfo,
-    ctx: Context,
+    ctx: RouteContext,
     parent?: { value: any, type: Class, decorators: any[] }
 }
 
@@ -267,9 +266,8 @@ export interface AsyncValidatorResult {
     messages: string[]
 }
 
-export type ValidatorFunction = (value: any, info: ValidatorInfo) => Promise<AsyncValidatorResult[] | string | undefined>
+export type ValidatorFunction = (value: any, info: ValidatorInfo) => undefined | string | AsyncValidatorResult[] | Promise<AsyncValidatorResult[] | string | undefined>
 export type ValidatorStore = { [key: string]: ValidatorFunction }
-
 
 
 // --------------------------------------------------------------------- //

--- a/packages/plumier/test/integration/validation/__snapshots__/validation.spec.ts.snap
+++ b/packages/plumier/test/integration/validation/__snapshots__/validation.spec.ts.snap
@@ -18,6 +18,55 @@ Object {
 }
 `;
 
+exports[`Custom Validation Should able to return AsyncValidatorResult from sync validation 1`] = `
+Object {
+  "message": Array [
+    Object {
+      "messages": Array [
+        "Must greater than 18",
+      ],
+      "path": Array [
+        "data",
+        "other",
+      ],
+    },
+  ],
+  "status": 422,
+}
+`;
+
+exports[`Custom Validation Should able to use async function as custom validator 1`] = `
+Object {
+  "message": Array [
+    Object {
+      "messages": Array [
+        "Must greater than 18",
+      ],
+      "path": Array [
+        "data",
+      ],
+    },
+  ],
+  "status": 422,
+}
+`;
+
+exports[`Custom Validation Should able to use sync function as custom validator 1`] = `
+Object {
+  "message": Array [
+    Object {
+      "messages": Array [
+        "Must greater than 18",
+      ],
+      "path": Array [
+        "data",
+      ],
+    },
+  ],
+  "status": 422,
+}
+`;
+
 exports[`Custom Validation Should be able to validate class and return several validation result 1`] = `
 Object {
   "message": Array [

--- a/packages/plumier/test/integration/validation/validation.spec.ts
+++ b/packages/plumier/test/integration/validation/validation.spec.ts
@@ -192,218 +192,13 @@ describe("Decouple Validation Logic", () => {
     })
 })
 
-
-
-// describe("Object Validation", () => {
-
-//     it("Should validate object with parameter properties", async () => {
-//         @domain()
-//         class ClientModel {
-//             constructor(
-//                 @val.email()
-//                 public email: string,
-//                 @val.email()
-//                 public secondaryEmail: string
-//             ) { }
-//         }
-//         const result = await validateMe(new ClientModel("kitty", "doggy"))
-//         expect(result).toMatchObject([
-//             { path: ["email"] },
-//             { path: ["secondaryEmail"] }
-//         ])
-//     })
-
-//     it("Should validate object with common property", async () => {
-//         @domain()
-//         class ClientModel {
-//             @val.email()
-//             public email: string = "kitty"
-//             @val.email()
-//             public secondaryEmail: string = "doggy"
-//         }
-//         const result = await validateMe(new ClientModel())
-//         expect(result).toMatchObject([
-//             { path: ["email"] },
-//             { path: ["secondaryEmail"] }
-//         ])
-//     })
-
-//     it("Should validate object with getter property", async () => {
-//         @domain()
-//         class ClientModel {
-//             @val.email()
-//             get email(): string { return "kitty" }
-//             @val.email()
-//             get secondaryEmail(): string { return "doggy" }
-//         }
-//         const result = await validateMe(new ClientModel())
-//         expect(result).toMatchObject([
-//             { path: ["email"] },
-//             { path: ["secondaryEmail"] }
-//         ])
-//     })
-
-//     it("Should validate nested object", async () => {
-//         @domain()
-//         class CreditCardModel {
-//             constructor(
-//                 @val.creditCard()
-//                 public creditCard: string,
-//             ) { }
-//         }
-//         @domain()
-//         class ClientModel {
-//             constructor(
-//                 @val.email()
-//                 public email: string,
-//                 @val.email()
-//                 public secondaryEmail: string,
-//                 public spouse: CreditCardModel
-//             ) { }
-//         }
-//         const result = await validateMe(new ClientModel("kitty", "doggy", new CreditCardModel("kitty")))
-//         expect(result).toMatchObject([
-//             { path: ["email"] },
-//             { path: ["secondaryEmail"] },
-//             { path: ["spouse", "creditCard"] }
-//         ])
-//     })
-// })
-
-// describe("Array Validation", () => {
-//     it("Should validate object inside array", async () => {
-//         @domain()
-//         class Dummy {
-//             constructor(
-//                 @val.email()
-//                 public email: string,
-//             ) { }
-//         }
-//         const result = await validateArray([new Dummy("support@gmail.com"), new Dummy("noreply@gmail.com"), new Dummy("kitty")], [], {} as any)
-//         expect(result).toMatchObject([
-//             { path: ["2", "email"] }
-//         ])
-//     })
-//     it("Should validate nested array inside object", async () => {
-//         @domain()
-//         class Empty {
-//             constructor(
-//                 public dummies: Dummy[],
-//             ) { }
-//         }
-//         @domain()
-//         class Dummy {
-//             constructor(
-//                 @val.email()
-//                 public email: string,
-//             ) { }
-//         }
-//         const dummies = [new Dummy("support@gmail.com"), new Dummy("noreply@gmail.com"), new Dummy("kitty")]
-//         const result = await validateArray([new Empty(dummies)], [], {} as any)
-//         expect(result).toMatchObject([
-//             { path: ["0", "dummies", "2", "email"] }
-//         ])
-//     })
-// })
-
-// describe("Durability", () => {
-//     it("Should treat property as required except @optional() defined", async () => {
-//         @domain()
-//         class ClientModel {
-//             constructor(
-//                 @val.email()
-//                 public email?: string | null | undefined,
-//             ) { }
-//         }
-//         expect((await validateMe(new ClientModel()))).toMatchObject([{ "messages": ["Required"] }])
-//         expect((await validateMe(new ClientModel("")))).toMatchObject([{ "messages": ["Required"] }])
-//         expect((await validateMe(new ClientModel("abc")))).toMatchObject([{ "messages": ["Invalid email address"] }])
-//         expect((await validateMe(new ClientModel("support@gmail.com")))).toEqual([])
-//     })
-
-//     it("Should skip required if @option() is provided", async () => {
-//         @domain()
-//         class ClientModel {
-//             constructor(
-//                 @val.optional()
-//                 @val.email()
-//                 public email?: string | null | undefined,
-//             ) { }
-//         }
-//         expect((await validateMe(new ClientModel())).length).toBe(0)
-//         expect((await validateMe(new ClientModel(""))).length).toBe(0)
-//         expect((await validateMe(new ClientModel(null))).length).toBe(0)
-//         expect((await validateMe(new ClientModel("abc")))).toMatchObject([{ "messages": ["Invalid email address"] }])
-//     })
-
-//     it("Should not error if provided boolean", async () => {
-//         @domain()
-//         class ClientModel {
-//             constructor(
-//                 @val.email()
-//                 public hasEmail: boolean,
-//             ) { }
-//         }
-//         const result = await validateMe(new ClientModel(false))
-//         expect(result).toMatchObject([{
-//             path: ["hasEmail"]
-//         }])
-//     })
-//     it("Should not error if provided number", async () => {
-//         @domain()
-//         class ClientModel {
-//             constructor(
-//                 @val.email()
-//                 public age: number,
-//             ) { }
-//         }
-//         const result = await validateMe(new ClientModel(50))
-//         expect(result).toMatchObject([{
-//             path: ["age"]
-//         }])
-//     })
-//     it("Should not error if provided function", async () => {
-//         @domain()
-//         class ClientModel {
-//             constructor(
-//                 @val.email()
-//                 public fn: () => void,
-//             ) { }
-//         }
-//         const result = await validateMe(new ClientModel(() => { }))
-//         expect(result).toMatchObject([{
-//             path: ["fn"]
-//         }])
-//     })
-
-// })
-
-// describe("Partial Validation", () => {
-//     class ClientModel {
-//         constructor(
-//             public name?: string,
-//             @val.email()
-//             public email?: string,
-//         ) { }
-//     }
-//     it("Should called without error", () => {
-//         const result = val.partial(ClientModel)
-//         expect(result).not.toBeNull()
-//     })
-//     it("Should skip required validation on partial type", async () => {
-//         const result = await validate(new ClientModel(), [<TypeDecorator>{ kind: "Override", type: ClientModel, info: "Partial" }], [], {} as any)
-//         expect(result).toEqual([])
-//     })
-// })
-
-
 describe("Custom Validation", () => {
 
     it("Should provided correct information for custom validation", async () => {
         async function customValidator(val: any, info: ValidatorInfo) {
             expect(info.name).toBe("data")
             expect(info.parent).toBeUndefined()
-            expect(info.route).toMatchSnapshot()
+            expect(info.ctx.route).toMatchSnapshot()
             return undefined
         }
         class UserController {
@@ -417,7 +212,46 @@ describe("Custom Validation", () => {
             .expect(200)
     })
 
-    it("Should provide parent value information", async () =>{
+    it("Should able to use sync function as custom validator", async () => {
+        class UserController {
+            @route.post()
+            save(@val.custom(val => val < 18 ? "Must greater than 18" : undefined) data: number) { }
+        }
+        const koa = await fixture(UserController).initialize()
+        const { body } = await supertest(koa.callback())
+            .post("/user/save")
+            .send({ data: 12 })
+            .expect(422)
+        expect(body).toMatchSnapshot()
+    })
+
+    it("Should able to return AsyncValidatorResult from sync validation", async () => {
+        class UserController {
+            @route.post()
+            save(@val.custom(v => v < 18 ? val.result("other", "Must greater than 18") : undefined) data: number) { }
+        }
+        const koa = await fixture(UserController).initialize()
+        const { body } = await supertest(koa.callback())
+            .post("/user/save")
+            .send({ data: 12 })
+            .expect(422)
+        expect(body).toMatchSnapshot()
+    })
+
+    it("Should able to use async function as custom validator", async () => {
+        class UserController {
+            @route.post()
+            save(@val.custom(async val => val < 18 ? "Must greater than 18" : undefined) data: number) { }
+        }
+        const koa = await fixture(UserController).initialize()
+        const { body } = await supertest(koa.callback())
+            .post("/user/save")
+            .send({ data: 12 })
+            .expect(422)
+        expect(body).toMatchSnapshot()
+    })
+
+    it("Should provide parent value information", async () => {
         @domain()
         class ClientModel {
             constructor(
@@ -466,7 +300,6 @@ describe("Custom Validation", () => {
             .expect(422)
         expect(result.body).toMatchSnapshot()
     })
-
 
     it("Should validate using decouple logic", async () => {
         function only18Plus() {
@@ -546,7 +379,6 @@ describe("Custom Validation", () => {
             .expect(422)
         expect(result.body).toMatchSnapshot()
     })
-
 
     it("Should be able to validate class and return several validation result", async () => {
         function checkConfirmPassword() {


### PR DESCRIPTION
## Sync or Async Callback on Custom Validator
This PR fixes the need of async function on custom validator.  

### Sync Custom Validator
Can be used as simple value validation

```typescript
@val.custom(val => val < 18 ? "Must be 18+" : undefined)
```

### Async Custom Validator 
Can be used as validation required long running process 

```typescript 
@val.custom(async val => {
       const coupon = await CouponModel.findOne({ id : val})
       if(!coupon.active) return "Coupon is not active"
})
```