### PR TITLE
docs: Fix tutorial match with exposed validator info property

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -341,10 +341,26 @@ Check the full [documentation](refs/authorization) for more information about Pl
 ## Performance
 Plumier relatively has small code base which make it light and fast. It uses Koa as its core http handler which is quite fast, below is comparison result of Koa, Plumier and Express.
 
-![Benchmarks](assets/benchmarks.png)
+```
+GET method benchmark starting...
 
-The benchmark project forked from Fastify benchmark project, you can test it your self [here](https://github.com/ktutnik/benchmarks). 
+Server       Base         Method         Req/s  Cost (%)
+plumier      koa          GET         33624.00     -0.06
+koa                       GET         33602.19      0.00
+express                   GET         17688.37      0.00
+nest         express      GET         16932.91      4.27
+loopback     express      GET          5174.61     70.75
 
+POST method benchmark starting...
 
+Server       Base         Method         Req/s  Cost (%)
+koa                       POST        12218.37      0.00
+plumier      koa          POST        11196.55      8.36
+express                   POST         9543.46      0.00
+nest         express      POST         6814.64     28.59
+loopback     express      POST         3108.91     67.42
+```
 
+Version 1.0.0-beta.9 successfully reduce the framework cost, its mean using Plumier is the same as using Koa + Koa Router + Joi stack with all of Plumier features. 
 
+The benchmark script can be found [here](https://github.com/ktutnik/full-stack-benchmarks).

--- a/docs/tutorials/basic-sql/08-Securing-Routes.md
+++ b/docs/tutorials/basic-sql/08-Securing-Routes.md
@@ -60,8 +60,8 @@ import { db } from "../../../model/db"
 import { Todo } from "../../../model/domain"
 
 function ownerOrAdmin() {
-    return authorize.custom(async ({role, parameters, user}) => {
-        const todo: Todo = await db("Todo").where({ id: parameters[0] }).first()
+    return authorize.custom(async ({role, ctx, user}) => {
+        const todo: Todo = await db("Todo").where({ id: ctx.parameters[0] }).first()
         return role.some(x => x === "Admin") || todo && todo.userId === user.userId
     }, "Admin|Owner")
 }
@@ -109,8 +109,8 @@ Navigate to `users-controller.ts` file and add the following code before `UsersC
 import { authorize } from "plumier"
 
 function ownerOrAdmin() {
-    return authorize.custom(async ({ role, user, parameters }) => {
-        return role.some(x => x === "Admin") || parameters[0] === user.userId
+    return authorize.custom(async ({ role, user, ctx }) => {
+        return role.some(x => x === "Admin") || ctx.parameters[0] === user.userId
     }, "Admin|Owner")
 }
 ```


### PR DESCRIPTION
Fix tutorial uses `parameter` property of the `AuthorizeMetadataInfo`.  #261 remove some parameters that make the tutorial unappropriate