### PR TITLE
fix: Fix Google oAuth endpoint scope to include email

### DIFF
--- a/packages/plumier/test/integration/social-login/__snapshots__/social-login.spec.ts.snap
+++ b/packages/plumier/test/integration/social-login/__snapshots__/social-login.spec.ts.snap
@@ -22,35 +22,31 @@ exports[`Callback View Should able to provide callback view 1`] = `
 `;
 
 exports[`Social Login Dialogs Should return facebook dialog properly 1`] = `
-Array [
-  "client_id",
-  "display",
-  "redirect_uri",
-]
+Object {
+  "client_id": "",
+  "display": "popup",
+}
 `;
 
 exports[`Social Login Dialogs Should return github dialog properly 1`] = `
-Array [
-  "client_id",
-  "redirect_uri",
-]
+Object {
+  "client_id": "",
+}
 `;
 
 exports[`Social Login Dialogs Should return gitlab dialog properly 1`] = `
-Array [
-  "client_id",
-  "redirect_uri",
-  "response_type",
-]
+Object {
+  "client_id": "",
+  "response_type": "code",
+}
 `;
 
 exports[`Social Login Dialogs Should return google dialog properly 1`] = `
-Array [
-  "access_type",
-  "client_id",
-  "include_granted_scopes",
-  "redirect_uri",
-  "response_type",
-  "scope",
-]
+Object {
+  "access_type": "offline",
+  "client_id": "",
+  "include_granted_scopes": "true",
+  "response_type": "code",
+  "scope": "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile",
+}
 `;

--- a/packages/plumier/test/integration/social-login/social-login.spec.ts
+++ b/packages/plumier/test/integration/social-login/social-login.spec.ts
@@ -15,6 +15,12 @@ function createApp() {
         .initialize()
 }
 
+function getParams(path:string){
+    const object = qs.parse(path)
+    const props = Object.keys(object).filter(x => x !== "redirect_uri")
+    return JSON.parse(JSON.stringify(object, props))
+}
+
 describe("Social Login Mock Test", () => {
     it("Should return profile properly", async () => {
         (axios.post as jest.Mock).mockReturnValue(axiosResult({ access_token: faker.random.uuid() }));
@@ -95,7 +101,7 @@ describe("Social Login Dialogs", () => {
             .expect(302)
         const parts = resp.get("location").split("?")
         expect(parts[0]).toBe("https://www.facebook.com/v4.0/dialog/oauth")
-        expect(Object.keys(qs.parse(parts[1])).sort()).toMatchSnapshot()
+        expect(getParams(parts[1])).toMatchSnapshot()
     })
 
     it("Should return google dialog properly", async () => {
@@ -105,7 +111,7 @@ describe("Social Login Dialogs", () => {
             .expect(302)
         const parts = resp.get("location").split("?")
         expect(parts[0]).toBe("https://accounts.google.com/o/oauth2/v2/auth")
-        expect(Object.keys(qs.parse(parts[1])).sort()).toMatchSnapshot()
+        expect(getParams(parts[1])).toMatchSnapshot()
     })
 
     it("Should return github dialog properly", async () => {
@@ -115,7 +121,7 @@ describe("Social Login Dialogs", () => {
             .expect(302)
         const parts = resp.get("location").split("?")
         expect(parts[0]).toBe("https://github.com/login/oauth/authorize")
-        expect(Object.keys(qs.parse(parts[1])).sort()).toMatchSnapshot()
+        expect(getParams(parts[1])).toMatchSnapshot()
     })
 
     it("Should return gitlab dialog properly", async () => {
@@ -125,6 +131,6 @@ describe("Social Login Dialogs", () => {
             .expect(302)
         const parts = resp.get("location").split("?")
         expect(parts[0]).toBe("https://gitlab.com/oauth/authorize")
-        expect(Object.keys(qs.parse(parts[1])).sort()).toMatchSnapshot()
+        expect(getParams(parts[1])).toMatchSnapshot()
     })
 })

--- a/packages/social-login/src/provider/google.ts
+++ b/packages/social-login/src/provider/google.ts
@@ -54,6 +54,6 @@ export class GoogleDialogProvider extends DialogProvider {
         access_type: "offline",
         include_granted_scopes: true,
         response_type: "code",
-        scope: "https://www.googleapis.com/auth/userinfo.profile"
+        scope: "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
     }
 }


### PR DESCRIPTION
This PR fix issue causing `GoogleProvider` (the callback) doesn't returned user email on the bound login status `@bind.loginStatus()`. 