### PR TITLE
fix: Fix custom validator can't be applied as class level decorator

### DIFF
--- a/packages/plumier/test/integration/validation/__snapshots__/validation.spec.ts.snap
+++ b/packages/plumier/test/integration/validation/__snapshots__/validation.spec.ts.snap
@@ -118,6 +118,23 @@ Object {
 }
 `;
 
+exports[`Custom Validation Should be able to validate class from the class decorator 1`] = `
+Object {
+  "message": Array [
+    Object {
+      "messages": Array [
+        "Password is not the same",
+      ],
+      "path": Array [
+        "model",
+        "confirmPassword",
+      ],
+    },
+  ],
+  "status": 422,
+}
+`;
+
 exports[`Custom Validation Should provide parent value information 1`] = `
 Object {
   "message": Array [


### PR DESCRIPTION
## Custom Validator as Class Decorator
This PR enables Plumier to treat custom validator applied as a class scope decorator like example below:

```typescript
function checkConfirmPassword() {
    return val.custom( x => {
        if(x.password !== x.confirmPassword)
            return val.result("confirmPassword", "Password is not the same")
    })
}

@domain()
// apply custom validator as class decorator
@checkConfirmPassword()
class User {
    constructor(
        public password: string,
        public confirmPassword: string
    ) { }
}
```