### PR TITLE
fix: Fix GitHub profile properties based on GitHub docs

### DIFF
--- a/packages/social-login/src/provider/github.ts
+++ b/packages/social-login/src/provider/github.ts
@@ -12,27 +12,41 @@ https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/
 */
 
 export interface GitHubProfile {
-    html_url: string,
-    id: number,
-    location: string,
-    login: string,
-    name: string,
-    node_id: string,
-    organizations_url: string,
-    public_gists: number,
-    public_repos: number,
-    received_events_url: string,
-    repos_url: string,
-    site_admin: boolean,
-    starred_url: string,
-    subscriptions_url: string,
-    type: string,
-    updated_at: string,
-    url: string,
+    login: string
+    id: number
+    node_id: string
+    avatar_url: string
+    gravatar_id: string
+    url: string
+    html_url: string
+    followers_url: string
+    following_url: string
+    gists_url: string
+    starred_url: string
+    subscriptions_url: string
+    organizations_url: string
+    repos_url: string
+    events_url: string
+    received_events_url: string
+    type: string
+    site_admin: boolean
+    name: string
+    company: string
+    blog: string
+    location: string
+    email: string
+    hireable: boolean
+    bio: string
+    public_repos: number
+    public_gists: number
+    followers: number
+    following: number
+    created_at: string
+    updated_at: string
 }
 
 
-export interface GitHubLoginStatus extends SocialLoginStatus<GitHubProfile> {}
+export interface GitHubLoginStatus extends SocialLoginStatus<GitHubProfile> { }
 
 export class GitHubProvider implements SocialAuthProvider {
     tokenEndPoint = "https://github.com/login/oauth/access_token"


### PR DESCRIPTION
This PR fixes GitHub profile properties based on GitHub documentation [here](https://developer.github.com/v3/users/#response)

```
{
  "login": "octocat",
  "id": 1,
  "node_id": "MDQ6VXNlcjE=",
  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
  "gravatar_id": "",
  "url": "https://api.github.com/users/octocat",
  "html_url": "https://github.com/octocat",
  "followers_url": "https://api.github.com/users/octocat/followers",
  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
  "organizations_url": "https://api.github.com/users/octocat/orgs",
  "repos_url": "https://api.github.com/users/octocat/repos",
  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
  "received_events_url": "https://api.github.com/users/octocat/received_events",
  "type": "User",
  "site_admin": false,
  "name": "monalisa octocat",
  "company": "GitHub",
  "blog": "https://github.com/blog",
  "location": "San Francisco",
  "email": "octocat@github.com",
  "hireable": false,
  "bio": "There once was...",
  "public_repos": 2,
  "public_gists": 1,
  "followers": 20,
  "following": 0,
  "created_at": "2008-01-14T04:33:35Z",
  "updated_at": "2008-01-14T04:33:35Z"
}
```