### PR TITLE
fix: Validation behavior is optional by default

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
     "path-to-regexp": "^6.1.0",
     "tinspector": "^2.2.9",
     "tslib": "^1.10.0",
-    "typedconverter": "^1.0.7"
+    "typedconverter": "^2.0.0"
   },
   "bugs": {
     "url": "https://github.com/plumier/plumier/issues"

--- a/packages/core/src/decorator.authorize.ts
+++ b/packages/core/src/decorator.authorize.ts
@@ -1,5 +1,4 @@
-import { decorate, mergeDecorator } from "tinspector"
-import { OptionalValidator, ValidatorDecorator } from "typedconverter"
+import { decorate } from "tinspector"
 
 import { AuthorizeCallback, AuthorizeDecorator, Authorizer } from "./authorization"
 import { errorMessage } from "./types"
@@ -34,12 +33,11 @@ class AuthDecoratorImpl {
      * @param roles List of roles allowed
      */
     role(...roles: string[]) {
-        const roleDecorator = this.custom(async (info, location) => {
+        return this.custom(async (info, location) => {
             const { role, value } = info
             const isAuthorized = roles.some(x => role.some(y => x === y))
             return location === "Parameter" ? !!value && isAuthorized : isAuthorized
         }, roles.join("|"))
-        return mergeDecorator(roleDecorator, decorate(<ValidatorDecorator>{ type: "tc:validator", validator: OptionalValidator }))
     }
 }
 

--- a/packages/core/src/decorator.bind.ts
+++ b/packages/core/src/decorator.bind.ts
@@ -1,10 +1,9 @@
+import { GetOption } from "cookies"
 import { Context } from "koa"
-import { decorateParameter, mergeDecorator } from "tinspector"
+import { decorateParameter } from "tinspector"
 
 import { BindingDecorator, HeaderPart, RequestPart } from "./binder"
 import { getChildValue } from "./common"
-import { val } from '.';
-import { GetOption } from 'cookies';
 
 
 export namespace bind {
@@ -94,7 +93,7 @@ export namespace bind {
      *     method(@bind.user() user:User){}
      */
     export function user() {
-        return mergeDecorator(val.optional(), ctxDecorator("user", "state.user"))
+        return ctxDecorator("user", "state.user")
     }
 
     /**
@@ -103,7 +102,7 @@ export namespace bind {
      *     method(@bind.cookie("name") cookie:string){}
      */
     export function cookie(name: string, opt?: GetOption) {
-        return mergeDecorator(val.optional(), bind.custom(ctx => ctx.cookies.get(name, opt), "cookie"))
+        return bind.custom(ctx => ctx.cookies.get(name, opt), "cookie")
     }
 
     /**

--- a/packages/plumier/test/integration/application/restful.spec.ts
+++ b/packages/plumier/test/integration/application/restful.spec.ts
@@ -13,7 +13,6 @@ describe("Restful API", () => {
             constructor(
                 public name: string,
                 public email: string,
-                @val.optional()
                 public id?: number,
             ) { }
         }
@@ -90,9 +89,7 @@ describe("Restful API", () => {
             constructor(
                 public name: string,
                 public age: number,
-                @val.optional()
                 public clientI?: number,
-                @val.optional()
                 public id?: number,
             ) { }
         }

--- a/packages/plumier/test/integration/authorization/jwt-auth.spec.ts
+++ b/packages/plumier/test/integration/authorization/jwt-auth.spec.ts
@@ -870,15 +870,12 @@ describe("JwtAuth", () => {
         class DomainBase {
             constructor(
                 @authorize.role("Machine")
-                @val.optional()
                 public id: number = 0,
 
                 @authorize.role("Machine")
-                @val.optional()
                 public createdAt: Date = new Date(),
 
                 @authorize.role("Machine")
-                @val.optional()
                 public deleted: boolean = false
             ) { }
         }

--- a/packages/plumier/test/integration/binder/binder.spec.ts
+++ b/packages/plumier/test/integration/binder/binder.spec.ts
@@ -25,7 +25,7 @@ describe("Parameter Binding", () => {
     describe("Boolean parameter binding", () => {
         class AnimalController {
             @route.get()
-            get(b: boolean) { return { b } }
+            get(@val.required() b: boolean) { return { b } }
         }
         it("Should convert Truthy as true", async () => {
             const callback = (await fixture(AnimalController).initialize()).callback()
@@ -70,7 +70,7 @@ describe("Parameter Binding", () => {
     describe("Number parameter binding", () => {
         class AnimalController {
             @route.get()
-            get(b: number) { return { b } }
+            get(@val.required() b: number) { return { b } }
         }
         it("Should return integer from string", async () => {
             await Supertest((await fixture(AnimalController).initialize()).callback())
@@ -137,7 +137,7 @@ describe("Parameter Binding", () => {
     describe("Date parameter binding", () => {
         class AnimalController {
             @route.get()
-            get(b: Date) { return { b } }
+            get(@val.required() b: Date) { return { b } }
         }
         it("Should return date from string", async () => {
             await Supertest((await fixture(AnimalController).initialize()).callback())
@@ -963,7 +963,7 @@ describe("Parameter Binding", () => {
                 }
             }
             const meta = reflect(AnimalController)
-            expect(meta.methods[0].parameters[0].decorators[1].name).toBe("user")
+            expect(meta.methods[0].parameters[0].decorators[0].name).toBe("user")
         })
     })
 
@@ -1124,7 +1124,7 @@ describe("Custom Converter", () => {
             name: string
             deceased: boolean
             birthday: Date
-            constructor(@val.optional() json: any) {
+            constructor(json: any) {
                 json = json || {}
                 this.id = json.id;
                 this.name = json.name

--- a/packages/plumier/test/integration/mongoose/mongoose.spec.ts
+++ b/packages/plumier/test/integration/mongoose/mongoose.spec.ts
@@ -460,7 +460,6 @@ describe("Automatically replace mongodb id into ObjectId on populate data", () =
             constructor(
                 public name: string,
                 @reflect.array(Image)
-                @val.optional()
                 public images: Image[]
             ) { }
         }

--- a/packages/plumier/test/integration/mongoose/unique-validator.spec.ts
+++ b/packages/plumier/test/integration/mongoose/unique-validator.spec.ts
@@ -137,7 +137,6 @@ describe("unique validator", () => {
         class User {
             constructor(
                 public name: string,
-                @val.optional()
                 @val.unique()
                 public email: string | undefined
             ) { }
@@ -157,7 +156,6 @@ describe("unique validator", () => {
         @collection()
         class User {
             constructor(
-                @val.optional()
                 @val.unique()
                 public email: string | undefined
             ) { }

--- a/packages/plumier/test/integration/social-login/controller/facebook-controller.ts
+++ b/packages/plumier/test/integration/social-login/controller/facebook-controller.ts
@@ -5,7 +5,7 @@ import {
     oAuthCallback,
     oAuthDialogEndPoint,
 } from "@plumier/social-login"
-import { bind } from "plumier"
+import { bind, val } from "plumier"
 
 import { fb } from "../config"
 

--- a/packages/plumier/test/integration/social-login/controller/github-controller.ts
+++ b/packages/plumier/test/integration/social-login/controller/github-controller.ts
@@ -1,5 +1,5 @@
 import { GitHubDialogProvider, GitHubLoginStatus, GitHubProvider, oAuthCallback, oAuthDialogEndPoint } from "@plumier/social-login"
-import { bind } from "plumier"
+import { bind, val } from "plumier"
 
 import { github } from "../config"
 

--- a/packages/plumier/test/integration/social-login/controller/gitlab-controller.ts
+++ b/packages/plumier/test/integration/social-login/controller/gitlab-controller.ts
@@ -1,5 +1,5 @@
 import { GitLabDialogProvider, GitLabLoginStatus, GitLabProvider, oAuthCallback, oAuthDialogEndPoint } from "@plumier/social-login"
-import { bind } from "plumier"
+import { bind, val } from "plumier"
 
 import { gitlab } from "../config"
 

--- a/packages/plumier/test/integration/social-login/controller/google-controller.ts
+++ b/packages/plumier/test/integration/social-login/controller/google-controller.ts
@@ -1,14 +1,15 @@
 import { GoogleDialogProvider, GoogleLoginStatus, GoogleProvider, oAuthCallback, oAuthDialogEndPoint } from "@plumier/social-login"
-import { bind } from "plumier"
+import { bind, val } from "plumier"
 
 import { google } from "../config"
+import { decorateParameter } from 'tinspector'
 
 export class GoogleController {
     @oAuthDialogEndPoint(new GoogleDialogProvider("/google/callback", google.appId))
     login() { }
 
     @oAuthCallback(new GoogleProvider(google.appId, google.appSecret))
-    callback(@bind.loginStatus() profile: GoogleLoginStatus) {
+    callback(@bind.loginStatus() @decorateParameter({ type: "dummy" }) profile: GoogleLoginStatus) {
         return profile
     }
 }

--- a/packages/plumier/test/integration/social-login/social-login.spec.ts
+++ b/packages/plumier/test/integration/social-login/social-login.spec.ts
@@ -64,7 +64,7 @@ describe("Social Login Mock Test", () => {
         const app = await createApp()
         const agent = supertest.agent(app.callback())
         const { body } = await agent
-            .get("/google/callback")
+            .get("/github/callback")
             .expect(200)
         expect(body.status).toBe("Failed")
         expect(body.error).toMatchObject({ message: "Authorization code is required" })

--- a/packages/plumier/test/integration/validation/__snapshots__/validation.spec.ts.snap
+++ b/packages/plumier/test/integration/validation/__snapshots__/validation.spec.ts.snap
@@ -315,21 +315,7 @@ Object {
 }
 `;
 
-exports[`Validation Parameter should be mandatory by default 1`] = `
-Object {
-  "message": Array [
-    Object {
-      "messages": Array [
-        "Required",
-      ],
-      "path": Array [
-        "email",
-      ],
-    },
-  ],
-  "status": 422,
-}
-`;
+exports[`Validation Parameter should be optional by default 1`] = `Object {}`;
 
 exports[`Validation Should validate model with correct path 1`] = `
 Object {

--- a/packages/plumier/test/integration/validation/validation.spec.ts
+++ b/packages/plumier/test/integration/validation/validation.spec.ts
@@ -15,14 +15,14 @@ import reflect from "tinspector"
 import { fixture } from "../../helper"
 
 describe("Validation", () => {
-    it("Parameter should be mandatory by default", async () => {
+    it("Parameter should be optional by default", async () => {
         class AnimalController {
             get(email: string) { }
         }
         const koa = await fixture(AnimalController).initialize()
         const result = await Supertest(koa.callback())
             .get("/animal/get")
-            .expect(422)
+            .expect(200)
         expect(result.body).toMatchSnapshot()
     })
 
@@ -32,6 +32,7 @@ describe("Validation", () => {
             constructor(
                 public id: number,
                 public name: string,
+                @val.required()
                 public deceased: boolean
             ) { }
         }
@@ -50,7 +51,7 @@ describe("Validation", () => {
     it("Should validate nested model with correct path", async () => {
         @domain()
         class TagModel {
-            constructor(public name: string, public id: number) { }
+            constructor(public name: string, @val.required() public id: number) { }
         }
         @domain()
         class AnimalModel {
@@ -83,9 +84,9 @@ describe("Validation", () => {
         expect(result.body).toMatchSnapshot()
     })
 
-    it("Should skip optional validation if provided undefined", async () => {
+    it("Should skip validation if no query provided", async () => {
         class AnimalController {
-            get(@val.optional() @val.email() email: string) { }
+            get(@val.email() email: string) { }
         }
         const koa = await fixture(AnimalController).initialize()
         const result = await Supertest(koa.callback())

--- a/packages/social-login/src/middleware.ts
+++ b/packages/social-login/src/middleware.ts
@@ -35,10 +35,10 @@ declare module "@plumier/core" {
 }
 
 bind.loginStatus = () => {
-    return mergeDecorator(decorateProperty(<BindingDecorator>{
+    return decorateProperty(<BindingDecorator>{
         type: "ParameterBinding", process: () => undefined,
         name: LoginStatusParameterBinding
-    }), val.optional())
+    })
 }
 
 export class OAuthCallbackMiddleware implements Middleware {


### PR DESCRIPTION
## Default Optional Validation
This PR change the validation behaviour which was required by default for each property / parameter changed to optional by default. 

This behaviour required to keep compatibility with other web framework and validation library.

If you have domain like below: 

```typescript
@domain()
class Animal {
    constructor(
        @val.required(),
        public id:number,
        @val.required()
        public name: string,
        public dateOfBirth: string
    ) { }
}
```

It's now possible to omit the `dateOfBirth` property because its now optional by default. 

```
{ "id": 1234, "name": "Mimi" }
```