### PR TITLE
fix: Fix @val.custom not being detected on @plumier/mongoose

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -277,6 +277,17 @@ export interface PlumierApplication extends Application {
 // --------------------------------------------------------------------- //
 
 
+declare module "typedconverter" {
+    namespace val {
+        export function custom(validator: CustomValidatorFunction): (...arg: any[]) => void
+        export function custom(validator: CustomValidator): (...arg: any[]) => void
+        export function custom(id: string): (...arg: any[]) => void
+        export function custom(id: symbol): (...arg: any[]) => void
+        export function custom(val: CustomValidatorFunction | string | symbol | CustomValidator): (...arg: any[]) => void
+        export function result(path: string, messages: string | string[]): AsyncValidatorResult[]
+    }
+}
+
 export interface ValidatorDecorator {
     type: "ValidatorDecorator",
     validator: CustomValidatorFunction | string | symbol,

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -40,17 +40,6 @@ function createVisitor(items: AsyncValidatorItem[]) {
     }
 }
 
-declare module "typedconverter" {
-    namespace val {
-        export function custom(validator: CustomValidatorFunction): (...arg: any[]) => void
-        export function custom(validator: CustomValidator): (...arg: any[]) => void
-        export function custom(id: string): (...arg: any[]) => void
-        export function custom(id: symbol): (...arg: any[]) => void
-        //export function custom(val: ValidatorFunction | string | symbol | CustomValidator): (...arg: any[]) => void
-        export function result(path: string, messages: string | string[]): AsyncValidatorResult[]
-    }
-}
-
 tc.val.custom = (val: CustomValidatorFunction | string | symbol | CustomValidator) => {
     return decorate(<ValidatorDecorator>{ type: "ValidatorDecorator", validator: val }, ["Class", "Property", "Parameter"])
 }

--- a/packages/mongoose/src/index.ts
+++ b/packages/mongoose/src/index.ts
@@ -138,11 +138,9 @@ async function isUnique(value: string, target: Class | undefined, field: string)
 
 declare module "typedconverter" {
     namespace val {
-        function custom(validator: CustomValidatorFunction): (...arg: any[]) => void
         function unique(): (target: any, name: string, index?: any) => void
     }
 }
-
 val.unique = () => val.custom(async (value, info) => {
     if(info.ctx.method.toLocaleLowerCase() === "post")
         return isUnique(value, info.parent && info.parent.type, info.name)


### PR DESCRIPTION
This PR fixes typedconverter `@val` augmentation issue on `@plumier/core`. This issue make `@val.custom()` and `@val.result()` can't be detected from other package, for example `@plumier/mongoose`