### PR TITLE
fix: Fix query case sensitivity issue on ctx.query and ctx.request.query

### DIFF
--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -3,8 +3,6 @@ id: middleware
 title: Middleware
 ---
 
-> Plumier supports Koa middleware out of the box, you can use any existing Koa middleware
-
 Plumier middleware works exactly like Koa middleware, it executed in a stack-like order and has full control of the next middleware. 
 
 The different between Plumier middleware and Koa middleware is Plumier middleware is a stateless class which has a method that act like pure function. It doesn't mutate things but returns value. With this behavior Plumier middleware relatively easy to unit test in isolation.

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -10,10 +10,9 @@ import { Configuration, HttpStatusError, RouteInfo, ValidationError } from "./ty
 // --------------------------------------------------------------------- //
 
 interface RouteMatcher {
-    match: RegExpExecArray | null,
-    query: any,
-    method: string,
     route: RouteInfo
+    keys: Key[],
+    match: RegExpExecArray,
 }
 
 // --------------------------------------------------------------------- //
@@ -25,22 +24,32 @@ function sendError(ctx: Context, status: number, message: any) {
     ctx.body = { status, message }
 }
 
-function getHandler(ctx: Context) {
+function getHandler(ctx: Context): RouteMatcher | undefined {
     for (const route of ctx.routes) {
         if (route.method !== ctx.method.toLowerCase()) continue
         const keys: Key[] = []
         const regexp = pathToRegexp(route.url, keys)
         const match = regexp.exec(ctx.path)
-        if (match) {
-            const query = keys.reduce((a, b, i) => {
-                a[b.name] = match![i + 1]
-                return a;
-            }, ctx.request.query)
-            return { route, query }
-        }
+        if (match)
+            return { route, keys, match }
     }
 }
 
+function createQuery(query: any, { keys, match }: RouteMatcher) {
+    const raw = keys.reduce((a, b, i) => {
+        a[b.name] = match![i + 1]
+        return a;
+    }, query)
+    return new Proxy(raw, {
+        get: (target, name) => {
+            for (const key in target) {
+                if (key.toLowerCase() === name.toString().toLowerCase())
+                    return target[key];
+            }
+            return target[name]
+        }
+    })
+}
 
 /* ------------------------------------------------------------------------------- */
 /* ------------------------------- ROUTER ---------------------------------------- */
@@ -55,7 +64,9 @@ function router(infos: RouteInfo[], config: Configuration) {
             ctx.routes = infos
             const handler = getHandlerCached(ctx)
             if (handler) {
-                ctx.request.query = handler.query
+                Object.defineProperty(ctx.request, "query", {
+                    value: createQuery(ctx.query, handler)
+                })
                 ctx.route = handler.route
             }
             const result = await pipe(ctx)

--- a/packages/plumier/test/integration/application/query.spec.ts
+++ b/packages/plumier/test/integration/application/query.spec.ts
@@ -1,0 +1,126 @@
+import { route, domain, bind } from "@plumier/core"
+import Plumier, { WebApiFacility } from '@plumier/plumier'
+import supertest = require('supertest')
+import { Context } from 'koa'
+import { fixture } from '../../../test/helper'
+
+
+describe("Request Query", () => {
+
+    function createResult(q: any) {
+        return {
+            property: {
+                lower: q.animalid,
+                upper: q.ANIMALID,
+            },
+            associative: {
+                lower: q["animalid"],
+                upper: q["ANIMALID"]
+            },
+        }
+    }
+
+
+    it("Should not cache query", async () => {
+        class AnimalController {
+            query(@bind.query() q: any) {
+                return q
+            }
+
+        }
+        const app = await fixture(AnimalController)
+        const koa = await app.initialize()
+        await supertest(koa.callback())
+            .get("/animal/query?data=123")
+            .expect(200, { data: "123" })
+        await supertest(koa.callback())
+            .get("/animal/query?data=456")
+            .expect(200, { data: "456" })
+    })
+
+    it("Should not cache query parameter", async () => {
+        class AnimalController {
+            @route.get(":id")
+            query(id: number) {
+                return { id }
+            }
+        }
+        const app = await fixture(AnimalController)
+        const koa = await app.initialize()
+        await supertest(koa.callback())
+            .get("/animal/123")
+            .expect(200, { id: 123 })
+        await supertest(koa.callback())
+            .get("/animal/456")
+            .expect(200, { id: 456 })
+    })
+
+    it("Should accessible case insensitively from ctx.request.query", async () => {
+        class AnimalController {
+            @route.get("")
+            query(@bind.query() q: any) {
+                return createResult(q)
+            }
+        }
+        const app = await fixture(AnimalController)
+        const koa = await app.initialize()
+        await supertest(koa.callback())
+            .get("/animal?animalId=123")
+            .expect(200, {
+                property: { lower: '123', upper: '123' },
+                associative: { lower: '123', upper: '123' }
+            })
+    })
+
+    it("Should accessible case insensitively from ctx.query", async () => {
+        class AnimalController {
+            @route.get("")
+            query(@bind.ctx() q: Context) {
+                return createResult(q.query)
+            }
+        }
+        const app = await fixture(AnimalController)
+        const koa = await app.initialize()
+        await supertest(koa.callback())
+            .get("/animal?animalId=123")
+            .expect(200, {
+                property: { lower: '123', upper: '123' },
+                associative: { lower: '123', upper: '123' }
+            })
+    })
+
+    it("Query parameter should accessible case insensitively from ctx.request.query", async () => {
+        class AnimalController {
+            @route.get(":animalId")
+            query(animalId:string, @bind.query() q: any) {
+                return createResult(q)
+            }
+        }
+        const app = await fixture(AnimalController)
+        const koa = await app.initialize()
+        await supertest(koa.callback())
+            .get("/animal/123")
+            .expect(200, {
+                property: { lower: '123', upper: '123' },
+                associative: { lower: '123', upper: '123' }
+            })
+    })
+
+    it("Query parameter should accessible case insensitively from ctx.query", async () => {
+        class AnimalController {
+            @route.get(":animalId")
+            query(animalId:string, @bind.ctx() q: Context) {
+                return createResult(q.query)
+            }
+        }
+        const app = await fixture(AnimalController)
+        const koa = await app.initialize()
+        await supertest(koa.callback())
+            .get("/animal/123")
+            .expect(200, {
+                property: { lower: '123', upper: '123' },
+                associative: { lower: '123', upper: '123' }
+            })
+    })
+
+})


### PR DESCRIPTION
## Query Case Insensitive 
This PR allows `ctx.query` and `ctx.request.query` accessible insensitively. 

for example giving the path `/path?animalId=123` can be accessed using:

```typescript
ctx.query.animalid
ctx.query.AnimalId
ctx.query.ANIMALID
ctx.query["animalid"]
ctx.query["AnimalId"]
ctx.query["ANIMALID"]
```