### PR TITLE
refactor: Add new types to follow the type convention

### DIFF
--- a/packages/core/src/authorization.ts
+++ b/packages/core/src/authorization.ts
@@ -2,13 +2,19 @@ import { ParameterReflection, PropertyReflection, reflect } from "tinspector"
 
 import { Class, hasKeyOf, isCustomClass } from "./common"
 import { HttpStatus } from "./http-status"
-import { AuthorizationContext, HttpStatusError, ActionContext, RouteInfo, Configuration, Middleware, Invocation, ActionResult } from "./types"
-import { Context } from 'koa'
+import { ActionContext, ActionResult, Configuration, HttpStatusError, Invocation, Middleware, RouteInfo } from "./types"
 
 
 // --------------------------------------------------------------------- //
 // ------------------------------- TYPES ------------------------------- //
 // --------------------------------------------------------------------- //
+
+interface AuthorizationContext {
+    value?: any
+    role: string[]
+    user: any
+    ctx: ActionContext
+}
 
 type AuthorizerFunction = (info: AuthorizationContext, location: "Class" | "Parameter" | "Method") => boolean | Promise<boolean>
 
@@ -22,6 +28,10 @@ interface AuthorizeDecorator {
 interface Authorizer {
     authorize(info: AuthorizationContext, location: "Class" | "Parameter" | "Method"): boolean | Promise<boolean>
 }
+
+type CustomAuthorizer = Authorizer
+type CustomAuthorizerFunction = AuthorizerFunction
+type AuthorizerContext = AuthorizationContext
 
 type RoleField = string | ((value: any) => Promise<string[]>)
 
@@ -166,5 +176,6 @@ class AuthorizerMiddleware implements Middleware {
 
 export {
     AuthorizerFunction, RoleField, Authorizer, checkAuthorize, AuthorizeDecorator,
-    getAuthorizeDecorators, updateRouteAuthorizationAccess, AuthorizerMiddleware
+    getAuthorizeDecorators, updateRouteAuthorizationAccess, AuthorizerMiddleware, 
+    CustomAuthorizer, CustomAuthorizerFunction, AuthorizationContext, AuthorizerContext
 }

--- a/packages/core/src/binder.ts
+++ b/packages/core/src/binder.ts
@@ -10,9 +10,10 @@ import { ActionContext, ActionResult, Invocation, Middleware } from "./types"
 // ------------------------------- TYPES ------------------------------- //
 // --------------------------------------------------------------------- // 
 
-interface BindingDecorator { type: "ParameterBinding", process: (ctx: Context) => any, name:string }
+interface BindingDecorator { type: "ParameterBinding", process: CustomBinderFunction, name:string }
 type RequestPart = keyof Request
 type HeaderPart = keyof IncomingHttpHeaders
+type CustomBinderFunction = (ctx:Context) => any
 
 declare module "koa" {
     interface Request {
@@ -66,4 +67,4 @@ class ParameterBinderMiddleware implements Middleware {
     }
 }
 
-export { RequestPart, HeaderPart, BindingDecorator, binder, ParameterBinderMiddleware }
+export { RequestPart, HeaderPart, BindingDecorator, binder, ParameterBinderMiddleware, CustomBinderFunction }

--- a/packages/core/src/decorator.bind.ts
+++ b/packages/core/src/decorator.bind.ts
@@ -2,7 +2,7 @@ import { GetOption } from "cookies"
 import { Context } from "koa"
 import { decorateParameter } from "tinspector"
 
-import { BindingDecorator, HeaderPart, RequestPart } from "./binder"
+import { BindingDecorator, HeaderPart, RequestPart, CustomBinderFunction } from "./binder"
 import { getChildValue } from "./common"
 
 
@@ -124,7 +124,7 @@ export namespace bind {
      * 
      * @param process callback function to process the Koa context
      */
-    export function custom(process: (ctx: Context) => any, name: string = "custom") {
+    export function custom(process: CustomBinderFunction, name: string = "custom") {
         return decorateParameter(<BindingDecorator>{ type: "ParameterBinding", process, name })
     }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 import { val } from "typedconverter"
 export { val }
-export { AuthorizerFunction, checkAuthorize, RoleField, Authorizer } from "./authorization";
-export { HeaderPart, RequestPart, BindingDecorator, binder, ParameterBinderMiddleware } from "./binder";
+export { AuthorizerFunction, checkAuthorize, RoleField, Authorizer, CustomAuthorizer, CustomAuthorizerFunction, AuthorizationContext, AuthorizerContext } from "./authorization";
+export { HeaderPart, RequestPart, BindingDecorator, binder, ParameterBinderMiddleware, CustomBinderFunction } from "./binder";
 export { invoke } from "./application-pipeline";
 export { response } from "./response";
 export { generateRoutes } from "./route-generator";
@@ -16,9 +16,10 @@ export { rest,  RestDecoratorImpl} from "./decorator.rest";
 export { HttpStatus } from "./http-status";
 export { validate, ValidatorMiddleware } from "./validator"
 export {
-    ActionResult, Application, AuthorizationContext, Configuration, DefaultFacility, CustomValidator,
+    ActionResult, Application, Configuration, DefaultFacility, CustomValidator,
     DependencyResolver, Facility, FileParser, FileUploadInfo, HttpMethod, HttpStatusError, Invocation, KoaMiddleware,
     Middleware, MiddlewareFunction, MiddlewareDecorator, MiddlewareUtil, PlumierApplication, PlumierConfiguration, RedirectActionResult,
     ActionContext, RouteInfo, RouteAnalyzerFunction, RouteAnalyzerIssue, ValidatorDecorator, CustomValidatorFunction,
     ValidatorContext, ValidationError, errorMessage, AsyncValidatorResult, DefaultDependencyResolver,
+    CustomMiddleware, CustomMiddlewareFunction
 } from "./types";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -132,6 +132,9 @@ export interface Middleware<T = Context> {
     execute(invocation: Readonly<Invocation<T>>): Promise<ActionResult>
 }
 
+export type CustomMiddleware = Middleware 
+export type CustomMiddlewareFunction = MiddlewareFunction
+
 export namespace MiddlewareUtil {
     export function fromKoa(middleware: KoaMiddleware): Middleware {
         return {
@@ -307,17 +310,6 @@ export interface CustomValidator {
     validate(value: any, info: ValidatorContext): undefined | string | AsyncValidatorResult[] | Promise<AsyncValidatorResult[] | string | undefined>
 }
 
-// --------------------------------------------------------------------- //
-// --------------------------- AUTHORIZATION --------------------------- //
-// --------------------------------------------------------------------- //
-
-
-export interface AuthorizationContext {
-    value?: any
-    role: string[]
-    user: any
-    ctx: ActionContext
-}
 
 
 // --------------------------------------------------------------------- //

--- a/packages/plumier/src/index.ts
+++ b/packages/plumier/src/index.ts
@@ -8,7 +8,8 @@ export {
     middleware, Middleware, MiddlewareUtil, ParameterBinderMiddleware,
     PlumierApplication, PlumierConfiguration, RequestPart, response, route, RouteInfo,
     val, validate, ValidatorContext, ValidatorMiddleware, rest, RestDecoratorImpl,
-    RouteDecoratorImpl
+    RouteDecoratorImpl, CustomBinderFunction, CustomAuthorizerFunction, CustomAuthorizer,
+    AuthorizerContext, CustomMiddleware, CustomMiddlewareFunction
 } from "@plumier/core"
 export * from "./facility"
 


### PR DESCRIPTION
## Type Naming Convention For Custom Components
All custom components (middleware, validator, binder, authorizer) now has naming convention `CustomXXX` for object type and `CustomXXXFunction` for function type.

Alias added: 

```
CustomMiddleware 
CustomMiddlewareFunction
CustomBinderFunction
CustomAuthorizer
CustomAuthorizerFunction
AuthorizerContext
CustomValidator 
CustomValidatiorFunction
ValidatorContext
```