### PR TITLE
fix: CORS is disabled by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
 		"reflect-metadata": "^0.1.13",
 		"ts-jest": "^24.2.0",
 		"tslint": "^5.20.1",
-		"typescript": "^3.7.4",
-		"npm-check-updates": "4.0.1"
+		"typescript": "^3.7.4"
 	},
 	"workspaces": [
 		"packages/*"

--- a/packages/plumier/src/facility.ts
+++ b/packages/plumier/src/facility.ts
@@ -3,6 +3,13 @@ import { Class, DefaultDependencyResolver, DefaultFacility, PlumierApplication, 
 import BodyParser from "koa-body"
 
 
+export interface WebApiFacilityOption {
+    controller?: string | Class | Class[],
+    bodyParser?: BodyParser.IKoaBodyOptions,
+    cors?: Cors.Options | boolean,
+    dependencyResolver?: DependencyResolver
+}
+
 /**
  * Preset configuration for building rest. This facility contains:
  * 
@@ -13,20 +20,21 @@ import BodyParser from "koa-body"
  * cors: @koa/cors
  */
 export class WebApiFacility extends DefaultFacility {
-    constructor(private opt?: {
-        controller?: string | Class | Class[],
-        bodyParser?: BodyParser.IKoaBodyOptions,
-        cors?: Cors.Options,
-        dependencyResolver?: DependencyResolver
-    }) { super() }
+    constructor(private opt?: WebApiFacilityOption) { super() }
 
     setup(app: Readonly<PlumierApplication>) {
-        app.koa.use(BodyParser(this.opt && this.opt.bodyParser))
-        app.koa.use(Cors(this.opt && this.opt.cors))
-        if(this.opt && this.opt.dependencyResolver)
-        app.set({ dependencyResolver: this.opt.dependencyResolver })
-        if (this.opt && this.opt.controller)
-            app.set({ controller: this.opt.controller })
+        const option: WebApiFacilityOption = { ...this.opt }
+        app.koa.use(BodyParser(option.bodyParser))
+        if (typeof option.cors !== "boolean" && option.cors) {
+            app.koa.use(Cors(option.cors))
+        }
+        else if(option.cors){
+            app.koa.use(Cors())
+        }
+        if (option.dependencyResolver)
+            app.set({ dependencyResolver: option.dependencyResolver })
+        if (option.controller)
+            app.set({ controller: option.controller })
     }
 }
 

--- a/packages/plumier/src/index.ts
+++ b/packages/plumier/src/index.ts
@@ -9,7 +9,7 @@ export {
     PlumierApplication, PlumierConfiguration, RequestPart, response, route, RouteInfo,
     val, validate, ValidatorContext, ValidatorMiddleware, rest, RestDecoratorImpl,
     RouteDecoratorImpl, CustomBinderFunction, CustomAuthorizerFunction, CustomAuthorizer,
-    AuthorizerContext, CustomMiddleware, CustomMiddlewareFunction
+    AuthorizerContext, CustomMiddleware, CustomMiddlewareFunction,
 } from "@plumier/core"
 export * from "./facility"
 

--- a/packages/plumier/test/integration/application/cors.spec.ts
+++ b/packages/plumier/test/integration/application/cors.spec.ts
@@ -1,0 +1,52 @@
+import Plumier, { WebApiFacility, WebApiFacilityOption } from "plumier"
+import Cors from "@koa/cors"
+import supertest from 'supertest'
+
+import Koa from "koa"
+
+describe("Cors", () => {
+    class AnimalController {
+        index() {
+            return { message: "Hello world!" }
+        }
+    }
+
+    function createApp(opt?: Cors.Options | boolean) {
+        return new Plumier()
+            .set({mode: "production"})
+            .set(new WebApiFacility({ controller: AnimalController, cors: opt }))
+            .initialize()
+    }
+
+    it("Should not active by default", async () => {
+        const app = await createApp()
+        const {header} = await supertest(app.callback())
+            .get("/animal/index")
+            .set("Origin", "http://plumierjs.com")
+            .expect(200)
+        expect(header["access-control-allow-origin"]).toBeUndefined()
+    })
+
+    it("Should provide default option if enabled", async () => {
+        const app = await createApp(true)
+        const {header} = await supertest(app.callback())
+            .get("/animal/index")
+            .set("Origin", "http://plumierjs.com")
+            .expect(200)
+        expect(header["access-control-allow-origin"]).toBe('http://plumierjs.com')
+    })
+
+    it("Should able to override option", async () => {
+        const app = await createApp({origin: "http://plumierjs.com"})
+        const {header: plumHeader} = await supertest(app.callback())
+            .get("/animal/index")
+            .set("Origin", "http://plumierjs.com")
+            .expect(200)
+        expect(plumHeader["access-control-allow-origin"]).toBe('http://plumierjs.com')
+        const {header} = await supertest(app.callback())
+            .get("/animal/index")
+            .set("Origin", "http://google.com")
+            .expect(200)
+        expect(header["access-control-allow-origin"]).toBe('http://plumierjs.com')
+    })
+})


### PR DESCRIPTION
CORS now disabled by default, and configurable from `WebApiFacility`. 

```typescript
// to use default setting 
app.set(new WebApiFacility({ cors: true }))

// to override default configuration
app.set(new WebApiFacility({ cors: { origin: "http://plumierjs.com" } }))
```