### PR TITLE
fix: Tweak middleware pipeline for performance and scale

### DIFF
--- a/packages/core/src/application-pipeline.ts
+++ b/packages/core/src/application-pipeline.ts
@@ -20,11 +20,8 @@ import { AuthorizerMiddleware } from './authorization'
 // ------------------------------ HELPERS ------------------------------ //
 // --------------------------------------------------------------------- //
 
-function pipeMiddleware(middlewares: (string | symbol | MiddlewareFunction | Middleware)[], ctx: Context, invocation: Invocation) {
-    for (let i = middlewares.length; i--;) {
-        invocation = new MiddlewareInvocation(middlewares[i], ctx, invocation)
-    }
-    return invocation.proceed()
+interface Pipe {
+    execute(ctx: Context): Invocation
 }
 
 
@@ -60,15 +57,12 @@ class NotFoundActionInvocation implements Invocation {
 class ActionInvocation implements Invocation {
     constructor(public ctx: ActionContext) { }
     async proceed(): Promise<ActionResult> {
-        const { config, route, parameters } = this.ctx
-        // 4. Controller Creation
-        const controller: any = config.dependencyResolver.resolve(route.controller.type)
-        // 5. Controller Invocation
-        const result = await (<Function>controller[route.action.name]).apply(controller, parameters)
-        const status = config.responseStatus && config.responseStatus[route.method] || 200
+        const controller: any = this.ctx.config.dependencyResolver.resolve(this.ctx.route.controller.type)
+        const result = await (<Function>controller[this.ctx.route.action.name]).apply(controller, this.ctx.parameters)
+        const status = this.ctx.config.responseStatus?.[this.ctx.route.method] ?? 200
         //if instance of action result, return immediately
         if (result && result.execute) {
-            result.status = result.status || status
+            result.status = result.status ?? status
             return result;
         }
         else {
@@ -77,17 +71,45 @@ class ActionInvocation implements Invocation {
     }
 }
 
+// --------------------------------------------------------------------- //
+// ------------------------------- PIPES ------------------------------- //
+// --------------------------------------------------------------------- //
+
+class MiddlewarePipe implements Pipe {
+    constructor(private middleware: string | symbol | MiddlewareFunction | Middleware, private next: Pipe) { }
+    execute(ctx: Context): Invocation<Context> {
+        return new MiddlewareInvocation(this.middleware, ctx, this.next.execute(ctx))
+    }
+}
+
+class ActionPipe implements Pipe {
+    execute(ctx: ActionContext): Invocation<Context> {
+        return new ActionInvocation(ctx)
+    }
+}
+
+class NotFoundPipe implements Pipe {
+    execute(ctx: ActionContext): Invocation<Context> {
+        return new NotFoundActionInvocation(ctx)
+    }
+}
+
 
 // --------------------------------------------------------------------- //
 // ------------------------------ PIPELINE ----------------------------- //
 // --------------------------------------------------------------------- //
 
+function link(middlewares: (string | symbol | MiddlewareFunction | Middleware)[], topNode: Pipe) {
+    for (let i = middlewares.length; i--;) {
+        topNode = new MiddlewarePipe(middlewares[i], topNode)
+    }
+    return topNode
+}
 
-function pipe(context: Context | ActionContext, caller: "system" | "invoke" = "system") {
-    context.state.caller = caller;
-    // request with controller's handler
+function createPipes(context: Context | ActionContext) {
     if (hasKeyOf<ActionContext>(context, "route")) {
-        const middlewares:(string | symbol | MiddlewareFunction | Middleware)[] = []
+        // request handled by controller (see application lifecycle)
+        const middlewares: (string | symbol | MiddlewareFunction | Middleware)[] = []
         // 1. global middlewares
         middlewares.push(...context.config.middlewares)
         // 2. parameter binding
@@ -98,19 +120,19 @@ function pipe(context: Context | ActionContext, caller: "system" | "invoke" = "s
         middlewares.push(new AuthorizerMiddleware())
         // 5. action middlewares
         middlewares.push(...MiddlewareUtil.extractDecorators(context.route))
-        // 6. execute action
-        return pipeMiddleware(middlewares, context, new ActionInvocation(context))
+        return link(middlewares, new ActionPipe())
     }
-    // request without controller handler
     else {
-        const globalMiddlewares = context.config.middlewares.slice(0)
-        return pipeMiddleware(globalMiddlewares, context, new NotFoundActionInvocation(context))
+        // unhandled request
+        return link(context.config.middlewares, new NotFoundPipe())
     }
 }
 
 function invoke(ctx: Context, route: RouteInfo) {
     ctx.route = route
-    return pipe(ctx, "invoke")
+    ctx.state.caller = "invoke"
+    const pipe = createPipes(ctx)
+    return pipe.execute(ctx).proceed()
 }
 
-export { invoke, pipe };
+export { invoke, createPipes, Pipe };

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -14,6 +14,7 @@ import {
     ValidatorContext,
     ValidatorDecorator,
 } from "./types"
+import { route } from './decorator.route'
 
 
 // --------------------------------------------------------------------- //
@@ -79,12 +80,13 @@ async function validateAsync(x: AsyncValidatorItem, ctx: ActionContext): Promise
 }
 
 async function validate(ctx: ActionContext) {
+    if(ctx.route.action.parameters.length === 0) return []
     const decsAsync: AsyncValidatorItem[] = []
     const visitors = [createVisitor(decsAsync), ...(ctx.config.typeConverterVisitors || [])]
     const result: any[] = []
     const issues: tc.ResultMessages[] = []
     //sync validations
-    for (const [index, parMeta] of ctx.route!.action.parameters.entries()) {
+    for (const [index, parMeta] of ctx.route.action.parameters.entries()) {
         const rawParameter = ctx.parameters[index]
         const parValue = tc.validate(rawParameter, {
             decorators: parMeta.decorators, path: parMeta.name, type: parMeta.type || Object,

--- a/packages/plumier/test/benchmark/options.ts
+++ b/packages/plumier/test/benchmark/options.ts
@@ -30,7 +30,7 @@ const jwtOption = <BenchmarkOption>{
 }
 
 const servers = [
-    "express",
+    //"express",
     "koa",
     "plumier",
 ]
@@ -38,5 +38,5 @@ const servers = [
 export const options = [
     ...servers.map(x => ({...getOption, path: join(__dirname, "server", x)})),
     ...servers.map(x => ({...postOption, path: join(__dirname, "server", x)})),
-    ...servers.map(x => ({...jwtOption, path: join(__dirname, "server", `${x}-jwt`)})),
+    //...servers.map(x => ({...jwtOption, path: join(__dirname, "server", `${x}-jwt`)})),
 ]

--- a/packages/plumier/test/benchmark/server/express-jwt.ts
+++ b/packages/plumier/test/benchmark/server/express-jwt.ts
@@ -13,7 +13,6 @@ const schema = Joi.object().keys({
 
 express()
     .use(bodyParser())
-    .use(Cors())
     .use(jwt({ secret }))
     .post("/", (req, res) => {
         const fix = schema.validate(req.body)

--- a/packages/plumier/test/benchmark/server/express.ts
+++ b/packages/plumier/test/benchmark/server/express.ts
@@ -11,7 +11,6 @@ const schema = Joi.object().keys({
 
 express()
     .use(bodyParser())
-    .use(Cors())
     .get("/", (req, res) => {
         res.send({ message: "Hello world!" })
     })

--- a/packages/plumier/test/benchmark/server/koa-jwt.ts
+++ b/packages/plumier/test/benchmark/server/koa-jwt.ts
@@ -21,7 +21,6 @@ const routes = new Router()
 
 new Koa()
     .use(bodyParser())
-    .use(Cors())
     .use(KoaJwt({ secret }))
     .use(routes.routes())
     .listen(5555)

--- a/packages/plumier/test/benchmark/server/koa.ts
+++ b/packages/plumier/test/benchmark/server/koa.ts
@@ -22,6 +22,5 @@ const routes = new Router()
 
 new Koa()
     .use(bodyParser())
-    .use(Cors())
     .use(routes.routes())
     .listen(5555)


### PR DESCRIPTION
## Middleware Pipeline Performance Improvement
This PR uses new logic to chain execution of middleware `Invocation`. Previously the middleware chain generated dynamically on every request, this technique quite fast but when number of middlewares increase it will cause scalability issue. 

The new logic cached (compile) the execution chain using linked list than reuse it on each request.