### PR TITLE
chore: Drop tests environment on Node.js 8 and update appropriate docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
   - stable
+  - 11
   - 10
-  - 8
 install: 
   - yarn install
 script: 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,8 @@ environment:
 
   matrix:
     - nodejs_version: "stable"
-    - nodejs_version: "8"
+    - nodejs_version: "11"
+    - nodejs_version: "10"
 
 build: off
 

--- a/packages/core/readme.md
+++ b/packages/core/readme.md
@@ -195,7 +195,7 @@ Creating lightweight framework is not easy, from result above Plumier only 1.84%
 
 ## Requirements
 * TypeScript
-* NodeJS >= 8.0.0
+* NodeJS >= 10.0.0
 * Visual Studio Code
 
 ## Contributing
@@ -203,7 +203,6 @@ To run Plumier project on local machine, some setup/app required
 
 ### App requirements
 * Visual Studio Code (Recommended)
-* Nodejs 8+
 * Yarn `npm install -g yarn`
 
 ### Local Setup

--- a/packages/jwt/readme.md
+++ b/packages/jwt/readme.md
@@ -195,7 +195,7 @@ Creating lightweight framework is not easy, from result above Plumier only 1.84%
 
 ## Requirements
 * TypeScript
-* NodeJS >= 8.0.0
+* NodeJS >= 10.0.0
 * Visual Studio Code
 
 ## Contributing
@@ -203,7 +203,6 @@ To run Plumier project on local machine, some setup/app required
 
 ### App requirements
 * Visual Studio Code (Recommended)
-* Nodejs 8+
 * Yarn `npm install -g yarn`
 
 ### Local Setup

--- a/packages/mongoose/readme.md
+++ b/packages/mongoose/readme.md
@@ -195,7 +195,7 @@ Creating lightweight framework is not easy, from result above Plumier only 1.84%
 
 ## Requirements
 * TypeScript
-* NodeJS >= 8.0.0
+* NodeJS >= 10.0.0
 * Visual Studio Code
 
 ## Contributing
@@ -203,7 +203,6 @@ To run Plumier project on local machine, some setup/app required
 
 ### App requirements
 * Visual Studio Code (Recommended)
-* Nodejs 8+
 * Yarn `npm install -g yarn`
 
 ### Local Setup

--- a/packages/multipart/readme.md
+++ b/packages/multipart/readme.md
@@ -195,7 +195,7 @@ Creating lightweight framework is not easy, from result above Plumier only 1.84%
 
 ## Requirements
 * TypeScript
-* NodeJS >= 8.0.0
+* NodeJS >= 10.0.0
 * Visual Studio Code
 
 ## Contributing
@@ -203,7 +203,6 @@ To run Plumier project on local machine, some setup/app required
 
 ### App requirements
 * Visual Studio Code (Recommended)
-* Nodejs 8+
 * Yarn `npm install -g yarn`
 
 ### Local Setup

--- a/packages/plumier/readme.md
+++ b/packages/plumier/readme.md
@@ -195,7 +195,7 @@ Creating lightweight framework is not easy, from result above Plumier only 1.84%
 
 ## Requirements
 * TypeScript
-* NodeJS >= 8.0.0
+* NodeJS >= 10.0.0
 * Visual Studio Code
 
 ## Contributing
@@ -203,7 +203,6 @@ To run Plumier project on local machine, some setup/app required
 
 ### App requirements
 * Visual Studio Code (Recommended)
-* Nodejs 8+
 * Yarn `npm install -g yarn`
 
 ### Local Setup

--- a/packages/serve-static/readme.md
+++ b/packages/serve-static/readme.md
@@ -195,7 +195,7 @@ Creating lightweight framework is not easy, from result above Plumier only 1.84%
 
 ## Requirements
 * TypeScript
-* NodeJS >= 8.0.0
+* NodeJS >= 10.0.0
 * Visual Studio Code
 
 ## Contributing
@@ -203,7 +203,6 @@ To run Plumier project on local machine, some setup/app required
 
 ### App requirements
 * Visual Studio Code (Recommended)
-* Nodejs 8+
 * Yarn `npm install -g yarn`
 
 ### Local Setup

--- a/packages/social-login/readme.md
+++ b/packages/social-login/readme.md
@@ -195,7 +195,7 @@ Creating lightweight framework is not easy, from result above Plumier only 1.84%
 
 ## Requirements
 * TypeScript
-* NodeJS >= 8.0.0
+* NodeJS >= 10.0.0
 * Visual Studio Code
 
 ## Contributing
@@ -203,7 +203,6 @@ To run Plumier project on local machine, some setup/app required
 
 ### App requirements
 * Visual Studio Code (Recommended)
-* Nodejs 8+
 * Yarn `npm install -g yarn`
 
 ### Local Setup

--- a/readme.md
+++ b/readme.md
@@ -195,7 +195,7 @@ Creating lightweight framework is not easy, from result above Plumier only 1.84%
 
 ## Requirements
 * TypeScript
-* NodeJS >= 8.0.0
+* NodeJS >= 10.0.0
 * Visual Studio Code
 
 ## Contributing
@@ -203,7 +203,6 @@ To run Plumier project on local machine, some setup/app required
 
 ### App requirements
 * Visual Studio Code (Recommended)
-* Nodejs 8+
 * Yarn `npm install -g yarn`
 
 ### Local Setup


### PR DESCRIPTION
Drop test environment on Node.js 8 since some dependencies required Node.js >= 10