### PR TITLE
fix: Expose headers and cookies on ActionResult

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,12 +12,13 @@ import { RoleField } from './authorization'
 // --------------------------------------------------------------------- //
 
 export class ActionResult {
+    headers: { [key: string]: string | string[] } = {}
+    cookies: { key: string, value?: string, option?: SetOption }[] = []
+    constructor(public body?: any, public status?: number) { }
+
     static fromContext(ctx: Context) {
         return new ActionResult(ctx.body, ctx.status)
     }
-    private readonly headers: { [key: string]: string | string[] } = {}
-    private readonly cookies: { key: string, value?: string, option?: SetOption }[] = []
-    constructor(public body?: any, public status?: number) { }
 
     setHeader(key: string, value: string | string[]) {
         this.headers[key] = value;

--- a/packages/plumier/test/integration/action-result/__snapshots__/action-result.spec.ts.snap
+++ b/packages/plumier/test/integration/action-result/__snapshots__/action-result.spec.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Action Result Should expose cookies 1`] = `
+Array [
+  Object {
+    "key": "key",
+    "option": Object {
+      "path": "/",
+      "sameSite": "strict",
+    },
+    "value": "value",
+  },
+  Object {
+    "key": "key2",
+    "option": Object {
+      "path": "/data",
+      "sameSite": "lax",
+    },
+    "value": "value2",
+  },
+]
+`;
+
+exports[`Action Result Should expose headers 1`] = `
+Object {
+  "x-api-key": "lorem ipsum",
+  "x-redirect": "https://google.com",
+}
+`;

--- a/packages/plumier/test/integration/action-result/action-result.spec.ts
+++ b/packages/plumier/test/integration/action-result/action-result.spec.ts
@@ -241,5 +241,19 @@ describe("Action Result", () => {
             .get("/animal/method")
             .expect(201, "Hello world!")
     })
+
+    it("Should expose cookies", () => {
+        const result = new ActionResult()
+            .setCookie("key", "value", { path: "/", sameSite: "strict" })
+            .setCookie("key2", "value2", { path: "/data", sameSite: "lax" })
+        expect(result.cookies).toMatchSnapshot()
+    })
+
+    it("Should expose headers", () => {
+        const result = new ActionResult()
+            .setHeader("x-api-key", "lorem ipsum")
+            .setHeader("x-redirect", "https://google.com")
+        expect(result.headers).toMatchSnapshot()
+    })
 })
 


### PR DESCRIPTION
## Headers and Cookies 

This PR exposes `headers` and `cookies` property of `ActionResult` object.

```typescript
const result = new ActionResult()
// headers
result.headers
// cookies
result.cookies
```