### PR TITLE
fix: Load default configuration from environment variable

### DIFF
--- a/docs/refs/Authorization.md
+++ b/docs/refs/Authorization.md
@@ -11,7 +11,11 @@ import { JwtAuthFacility } from "@plumier/jwt"
 
 const app = new Plumier()
 app.set(new JwtAuthFacility({ secret: "<your secret key>" }))
+// looking for environment variable PLUM_JWT_SECRET
+app.set(new JwtAuthFacility())
 ```
+
+>  If no `secret` provide `JwtAuthFacility` will check for environment variable named `PLUM_JWT_SECRET`, if both not provided an error will be thrown.
 
 ## Setup
 Plumier authorization uses standard token based authentication using json web token, internally it uses [koa-jwt](https://github.com/koajs/jwt) middleware. 

--- a/docs/refs/Mongoose-Helper.md
+++ b/docs/refs/Mongoose-Helper.md
@@ -10,10 +10,17 @@ MongoDB helper is optional in Plumier, it can be enabled by installing `@plumier
 
 ```typescript
 const plum = new Plumier()
-plum.set(new MongooseFacility({uri: "mongodb://localhost:27017/test-data"}))
+plum.set(new MongooseFacility({ uri: "mongodb://localhost:27017/test-data" }))
+//if no uri provided will check for environment variable PLUM_MONGODB_URI
+plum.set(new MongooseFacility())
 ```
 
 Mongoose facility will automatically connect to the MongoDB database and make sure it ready before application started.
+
+There are several ways to use the mongodb connection: 
+1. By providing the uri on the `MongooseFacility` constructor, like example above.
+2. By providing the environment variable named `PLUM_MONGODB_URI`. This can be achieve using `.env` file or by set the environment variable manually.
+3. If none above provided, connection should be done manually using `mongoose.connect()` function. 
 
 ## Mark Domain Model For Schema Generated
 Your domain model and you MongoDB collection is not 1 : 1 relation, means not all domain model will will have an appropriate MongoDB collection. 

--- a/docs/refs/Social-Login.md
+++ b/docs/refs/Social-Login.md
@@ -37,6 +37,29 @@ const plumier = new Plumier()
 
 All OAuth provider facility (`FacebookOAuthFacility`, `GoogleOAuthFacility`, `GitHubOAuthFacility`, `GitLabOAuthFacility`) receive option parameter which required a client id and client secret. This value can be found in the appropriate social login console application. 
 
+## Environment Variable for Default Configuration
+All OAuth provider facility can be instantiated without parameters, It will automatically check for the environment variable for each Client ID and Client Secret. For example if the registration is like below
+
+
+```typescript
+const plumier = new Plumier()
+    .set(new WebApiFacility())
+    .set(new OAuthFacility())
+    .set(new FacebookOAuthFacility())
+    .initialize()
+```
+
+`FacebookOAuthFacility` will search for environment variable `PLUM_FACEBOOK_CLIENT_ID` and `PLUM_FACEBOOK_CLIENT_SECRET`. If both not found an error will be thrown.
+
+
+| Facility                | Client ID                 | Client Secret                 |
+| ----------------------- | ------------------------- | ----------------------------- |
+| `FacebookOAuthFacility` | `PLUM_FACEBOOK_CLIENT_ID` | `PLUM_FACEBOOK_CLIENT_SECRET` |
+| `GoogleOAuthFacility`   | `PLUM_GOOGLE_CLIENT_ID`   | `PLUM_GOOGLE_CLIENT_SECRET`   |
+| `GitHubOAuthFacility`   | `PLUM_GITHUB_CLIENT_ID`   | `PLUM_GITHUB_CLIENT_SECRET`   |
+| `GitLabOAuthFacility`   | `PLUM_GITLAB_CLIENT_ID`   | `PLUM_GITLAB_CLIENT_SECRET`   |
+
+
 ## Showing The Login Page
 
 Plumier provided endpoints that will be redirected to the social media login page. It generate the required parameter including the csrf token and then redirect the request to the generated url.

--- a/packages/jwt/src/index.ts
+++ b/packages/jwt/src/index.ts
@@ -9,9 +9,9 @@ import jwt from "koa-jwt"
 export type RoleField = string | ((value: any) => Promise<string[]>)
 
 export interface JwtAuthFacilityOption {
-    secret: string,
+    secret?: string,
     roleField?: RoleField,
-    global?: (...args:any[]) => void
+    global?: (...args: any[]) => void
 }
 
 /* ------------------------------------------------------------------------------- */
@@ -19,14 +19,16 @@ export interface JwtAuthFacilityOption {
 /* ------------------------------------------------------------------------------- */
 
 export class JwtAuthFacility extends DefaultFacility {
-    constructor(private option: JwtAuthFacilityOption & jwt.Options) { super() }
+    constructor(private option?: JwtAuthFacilityOption & jwt.Options) { super() }
 
     setup(app: Readonly<PlumierApplication>) {
-        Object.assign(app.config, { 
-            enableAuthorization: true, 
-            roleField: this.option.roleField || "role",
-            globalAuthorizationDecorators: this.option.global
-         })
-        app.koa.use(KoaJwt({ cookie: "Authorization", ...this.option, secret: this.option.secret, passthrough: true }))
+        Object.assign(app.config, {
+            enableAuthorization: true,
+            roleField: this.option?.roleField || "role",
+            globalAuthorizationDecorators: this.option?.global
+        })
+        const secret = this.option?.secret ?? process.env.PLUM_JWT_SECRET
+        if(!secret) throw new Error("JWT Secret not provided. Provide secret on JwtAuthFacility constructor or environment variable PLUM_JWT_SECRET")
+        app.koa.use(KoaJwt({ cookie: "Authorization", ...this.option, secret, passthrough: true }))
     }
 }

--- a/packages/mongoose/src/index.ts
+++ b/packages/mongoose/src/index.ts
@@ -22,7 +22,7 @@ export type Constructor<T> = new (...args: any[]) => T
 export type SchemaRegistry = { [key: string]: Mongoose.Schema }
 export interface MongooseFacilityOption {
     model?: string | Class | Class[]
-    uri: string,
+    uri?: string,
     schemaGenerator?: SchemaGenerator
 }
 export interface SubSchema {
@@ -179,11 +179,11 @@ function relationToObjectIdVisitor(i: VisitorInvocation): Result {
 
 export class MongooseFacility extends DefaultFacility {
     option: MongooseFacilityOption
-    constructor(opts: MongooseFacilityOption) {
+    constructor(opts?: MongooseFacilityOption) {
         super()
-        const model = opts.model || "./model"
+        const model = opts?.model ?? "./model"
         const domain = typeof model === "string" ? isAbsolute(model) ?
-            model! : join(dirname(module.parent!.filename), model) : model
+            model : join(dirname(module.parent!.filename), model) : model
         this.option = { ...opts, model: domain }
     }
 
@@ -200,7 +200,9 @@ export class MongooseFacility extends DefaultFacility {
         //register custom converter
         app.set({ typeConverterVisitors: [relationToObjectIdVisitor] })
         Mongoose.set("useUnifiedTopology", true)
-        await Mongoose.connect(this.option.uri, { useNewUrlParser: true })
+        const uri = this.option.uri ?? process.env.PLUM_MONGODB_URI
+        if (uri)
+            await Mongoose.connect(uri, { useNewUrlParser: true })
     }
 }
 

--- a/packages/social-login/src/facebook.ts
+++ b/packages/social-login/src/facebook.ts
@@ -37,18 +37,18 @@ function transform(value: FacebookProfile): OAuthUser {
 }
 
 class FacebookOAuthFacility extends OAuthProviderBaseFacility {
-    constructor(opt: OAuthProviderOption) {
+    constructor(opt?: OAuthProviderOption) {
         super({
-            ...opt,
+            ...opt, 
             profile: {
                 endpoint: profileEndPoint,
-                params: { fields: "id,name,first_name,last_name,picture.type(large)", ...opt.profileParams },
+                params: { fields: "id,name,first_name,last_name,picture.type(large)", ...opt?.profileParams },
                 transformer: transform
             },
             login: { endpoint: loginEndpoint, params: { display: "popup" } },
             token: { endpoint: tokenEndPoint, params: {} },
             provider: "Facebook"
-        }, opt.loginEndPoint ?? "/auth/facebook/login")
+        }, opt?.loginEndPoint ?? "/auth/facebook/login")
     }
 }
 

--- a/packages/social-login/src/github.ts
+++ b/packages/social-login/src/github.ts
@@ -54,12 +54,12 @@ function transform(value: GitHubProfile): OAuthUser {
 }
 
 class GitHubOAuthFacility extends OAuthProviderBaseFacility {
-    constructor(opt: OAuthProviderOption) {
+    constructor(opt?: OAuthProviderOption) {
         super({
             ...opt,
             profile: {
                 endpoint: profileEndPoint,
-                params: { ...opt.profileParams },
+                params: { ...opt?.profileParams },
                 transformer: transform
             },
             login: {
@@ -71,7 +71,7 @@ class GitHubOAuthFacility extends OAuthProviderBaseFacility {
                 params: { }
             },
             provider: "GitHub"
-        }, opt.loginEndPoint ?? "/auth/github/login")
+        }, opt?.loginEndPoint ?? "/auth/github/login")
     }
 }
 

--- a/packages/social-login/src/gitlab.ts
+++ b/packages/social-login/src/gitlab.ts
@@ -52,12 +52,12 @@ function transform(value: GitLabProfile): OAuthUser {
 }
 
 class GitLabOAuthFacility extends OAuthProviderBaseFacility {
-    constructor(opt: OAuthProviderOption) {
+    constructor(opt?: OAuthProviderOption) {
         super({
             ...opt,
             profile: {
                 endpoint: profileEndPoint,
-                params: { ...opt.profileParams },
+                params: { ...opt?.profileParams },
                 transformer: transform
             },
             login: {
@@ -71,7 +71,7 @@ class GitLabOAuthFacility extends OAuthProviderBaseFacility {
                 params: { }
             },
             provider: "GitLab"
-        }, opt.loginEndPoint ?? "/auth/gitlab/login")
+        }, opt?.loginEndPoint ?? "/auth/gitlab/login")
     }
 }
 

--- a/packages/social-login/src/google.ts
+++ b/packages/social-login/src/google.ts
@@ -30,12 +30,12 @@ function transform(value: GoogleProfile): OAuthUser {
 }
 
 class GoogleOAuthFacility extends OAuthProviderBaseFacility {
-    constructor(opt: OAuthProviderOption) {
+    constructor(opt?: OAuthProviderOption) {
         super({
             ...opt,
             profile: {
                 endpoint: profileEndPoint,
-                params: { ...opt.profileParams },
+                params: { ...opt?.profileParams },
                 transformer: transform
             },
             login: {
@@ -52,7 +52,7 @@ class GoogleOAuthFacility extends OAuthProviderBaseFacility {
                 params: { grant_type: "authorization_code" }
             },
             provider: "Google"
-        }, opt.loginEndPoint ?? "/auth/google/login")
+        }, opt?.loginEndPoint ?? "/auth/google/login")
     }
 }
 

--- a/tests/authorization/__snapshots__/jwt-auth.spec.ts.snap
+++ b/tests/authorization/__snapshots__/jwt-auth.spec.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JwtAuth Default Configuration Should throw error when no secret provided nor environment variable 1`] = `
+Array [
+  Array [
+    "JWT Secret not provided. Provide secret on JwtAuthFacility constructor or environment variable PLUM_JWT_SECRET",
+  ],
+]
+`;

--- a/tests/mongoose/mongoose.spec.ts
+++ b/tests/mongoose/mongoose.spec.ts
@@ -392,7 +392,6 @@ describe("Proxy", () => {
     })
 })
 
-
 describe("Analysis", () => {
     beforeEach(() => clearCache())
     afterEach(async () => await Mongoose.disconnect())
@@ -544,4 +543,29 @@ describe("Automatically replace mongodb id into ObjectId on populate data", () =
             .expect(200)
         expect(fn.mock.calls[0][0]).toBe("string")
     })
+})
+
+
+describe("Default MongoDB Uri", () => {
+    beforeEach(() => clearCache())
+    afterEach(async () => await Mongoose.disconnect())
+
+    it("Should not connect if no URI provided nor environment variable", async () => {
+        const connect = Mongoose.connect
+        Mongoose.connect = jest.fn()
+        delete process.env.MONGODB_URI
+        const facility = new MongooseFacility()
+        await facility.initialize(<PlumierApplication>new Plumier().set({ mode: "production" }))
+        expect(Mongoose.connect).not.toBeCalled()
+        Mongoose.connect = connect
+    })
+
+    it("Should check for PLUM_MONGODB_URI environment variable", async () => {
+        process.env.PLUM_MONGODB_URI = "mongodb://localhost:27017/lorem"
+        const facility = new MongooseFacility()
+        await facility.initialize(<PlumierApplication>new Plumier().set({ mode: "production" }))
+        expect(Mongoose.connection.readyState).toBe(1)
+        expect(Mongoose.connection.db.databaseName).toBe("lorem")
+    })
+
 })

--- a/tests/social-login-web/__snapshots__/facebook.spec.ts.snap
+++ b/tests/social-login-web/__snapshots__/facebook.spec.ts.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FacebookOAuthFacility Should throw error when no clientId default configuration provided 1`] = `
+Array [
+  Array [
+    [Error: Client id for Facebook not provided],
+  ],
+]
+`;
+
+exports[`FacebookOAuthFacility Should throw error when no clientSecret default configuration provided 1`] = `
+Array [
+  Array [
+    [Error: Client secret for Facebook not provided],
+  ],
+]
+`;
+
+exports[`FacebookOAuthFacility Should use default configuration 1`] = `
+Array [
+  "https://graph.facebook.com/v4.0/oauth/access_token",
+  Object {
+    "client_id": "123",
+    "client_secret": "secret",
+    "code": "lorem",
+    "redirect_uri": "http://127.0.0.1/auth/facebook/callback",
+  },
+  Object {
+    "headers": Object {
+      "Accept": "application/json",
+    },
+  },
+]
+`;
+
 exports[`Login Endpoint Should include other required parameters 1`] = `
 Object {
   "client_id": "123456",

--- a/tests/social-login-web/__snapshots__/github.spec.ts.snap
+++ b/tests/social-login-web/__snapshots__/github.spec.ts.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GitHubOAuthFacility Should throw error when no clientId default configuration provided 1`] = `
+Array [
+  Array [
+    [Error: Client id for GitHub not provided],
+  ],
+]
+`;
+
+exports[`GitHubOAuthFacility Should throw error when no clientSecret default configuration provided 1`] = `
+Array [
+  Array [
+    [Error: Client secret for GitHub not provided],
+  ],
+]
+`;
+
+exports[`GitHubOAuthFacility Should use default configuration 1`] = `
+Array [
+  "https://github.com/login/oauth/access_token",
+  Object {
+    "client_id": "123",
+    "client_secret": "secret",
+    "code": "lorem",
+    "redirect_uri": "http://127.0.0.1/auth/github/callback",
+  },
+  Object {
+    "headers": Object {
+      "Accept": "application/json",
+    },
+  },
+]
+`;
+
 exports[`Login Endpoint Should include other required parameters 1`] = `
 Object {
   "client_id": "123456",

--- a/tests/social-login-web/__snapshots__/gitlab.spec.ts.snap
+++ b/tests/social-login-web/__snapshots__/gitlab.spec.ts.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GitLabOAuthFacility Should throw error when no clientId default configuration provided 1`] = `
+Array [
+  Array [
+    [Error: Client id for GitLab not provided],
+  ],
+]
+`;
+
+exports[`GitLabOAuthFacility Should throw error when no clientSecret default configuration provided 1`] = `
+Array [
+  Array [
+    [Error: Client secret for GitLab not provided],
+  ],
+]
+`;
+
+exports[`GitLabOAuthFacility Should use default configuration 1`] = `
+Array [
+  "https://gitlab.com/oauth/token",
+  Object {
+    "client_id": "123",
+    "client_secret": "secret",
+    "code": "lorem",
+    "redirect_uri": "http://127.0.0.1/auth/gitlab/callback",
+  },
+  Object {
+    "headers": Object {
+      "Accept": "application/json",
+    },
+  },
+]
+`;
+
 exports[`Login Endpoint Should include other required parameters 1`] = `
 Object {
   "client_id": "123456",

--- a/tests/social-login-web/__snapshots__/google.spec.ts.snap
+++ b/tests/social-login-web/__snapshots__/google.spec.ts.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GoogleOAuthFacility Should throw error when no clientId default configuration provided 1`] = `
+Array [
+  Array [
+    [Error: Client id for Google not provided],
+  ],
+]
+`;
+
+exports[`GoogleOAuthFacility Should throw error when no clientSecret default configuration provided 1`] = `
+Array [
+  Array [
+    [Error: Client secret for Google not provided],
+  ],
+]
+`;
+
+exports[`GoogleOAuthFacility Should use default configuration 1`] = `
+Array [
+  "https://www.googleapis.com/oauth2/v4/token",
+  Object {
+    "client_id": "123",
+    "client_secret": "secret",
+    "code": "lorem",
+    "grant_type": "authorization_code",
+    "redirect_uri": "http://127.0.0.1/auth/google/callback",
+  },
+  Object {
+    "headers": Object {
+      "Accept": "application/json",
+    },
+  },
+]
+`;
+
 exports[`Login Endpoint Should include other required parameters 1`] = `
 Object {
   "access_type": "offline",

--- a/tests/social-login-web/facebook.spec.ts
+++ b/tests/social-login-web/facebook.spec.ts
@@ -23,6 +23,12 @@ function appStub(opt?: { controller?: Class, csrfEndPoint?: string, loginEndPoin
         .initialize()
 }
 
+const getState = async (rqs: supertest.SuperTest<supertest.Test>) => {
+    await rqs.get("/auth/csrf-secret")
+    const resp = await rqs.get("/auth/facebook/login")
+    return new URL(resp.header["location"]).searchParams.get("state")
+}
+
 jest.mock("axios")
 
 function mockAxios() {
@@ -50,6 +56,75 @@ describe("FacebookOAuthFacility", () => {
         }
         expect(appStub({ controller: AuthController }))
             .rejects.toThrowError("Parameterized route is not supported on Facebook callback uri")
+    })
+
+    it("Should use default configuration", async () => {
+        process.env.PLUM_FACEBOOK_CLIENT_ID = "123"
+        process.env.PLUM_FACEBOOK_CLIENT_SECRET = "secret"
+        mockAxios()
+        const fn = jest.fn()
+        class AuthController {
+            @redirectUri("Facebook")
+            @route.get("/auth/facebook/callback")
+            callback(@bind.oAuthUser() user: OAuthUser) {
+                fn(user)
+            }
+        }
+        const app = await fixture(AuthController)
+            .set(new OAuthFacility())
+            .set(new FacebookOAuthFacility())
+            .initialize()
+        const request = await supertest.agent(app.callback())
+        const state = await getState(request)
+        await request.get(`/auth/facebook/callback?code=lorem&state=${state}`)
+            .expect(200)
+        const tokenCall: any[] = (axios.post as jest.Mock).mock.calls[0]
+        tokenCall[1].redirect_uri = tokenCall[1].redirect_uri.replace(/:[0-9]{4,5}/, "")
+        expect(tokenCall).toMatchSnapshot()
+    })
+
+    it("Should throw error when no clientId default configuration provided", async () => {
+        delete process.env.PLUM_FACEBOOK_CLIENT_ID
+        process.env.PLUM_FACEBOOK_CLIENT_SECRET = "secret"
+        const fn = jest.fn()
+        try {
+            class AuthController {
+                @redirectUri("Facebook")
+                @route.get("/auth/facebook/callback")
+                callback(@bind.oAuthUser() user: OAuthUser) {
+                }
+            }
+            await fixture(AuthController)
+                .set(new OAuthFacility())
+                .set(new FacebookOAuthFacility())
+                .initialize()
+        }
+        catch (e) {
+            fn(e)
+        }
+        expect(fn.mock.calls).toMatchSnapshot()
+    })
+
+    it("Should throw error when no clientSecret default configuration provided", async () => {
+        process.env.PLUM_FACEBOOK_CLIENT_ID = "1234"
+        delete process.env.PLUM_FACEBOOK_CLIENT_SECRET
+        const fn = jest.fn()
+        try {
+            class AuthController {
+                @redirectUri("Facebook")
+                @route.get("/auth/facebook/callback")
+                callback(@bind.oAuthUser() user: OAuthUser) {
+                }
+            }
+            await fixture(AuthController)
+                .set(new OAuthFacility())
+                .set(new FacebookOAuthFacility())
+                .initialize()
+        }
+        catch (e) {
+            fn(e)
+        }
+        expect(fn.mock.calls).toMatchSnapshot()
     })
 })
 
@@ -166,11 +241,6 @@ describe("Login Endpoint", () => {
 })
 
 describe("Redirect URI Handler", () => {
-    const getState = async (rqs: supertest.SuperTest<supertest.Test>) => {
-        await rqs.get("/auth/csrf-secret")
-        const resp = await rqs.get("/auth/facebook/login")
-        return new URL(resp.header["location"]).searchParams.get("state")
-    }
 
     it("Should handle redirection properly", async () => {
         mockAxios()

--- a/tests/social-login-web/github.spec.ts
+++ b/tests/social-login-web/github.spec.ts
@@ -23,6 +23,12 @@ function appStub(opt?: { controller?: Class, csrfEndPoint?: string, loginEndPoin
         .initialize()
 }
 
+const getState = async (rqs: supertest.SuperTest<supertest.Test>) => {
+    await rqs.get("/auth/csrf-secret")
+    const resp = await rqs.get("/auth/github/login")
+    return new URL(resp.header["location"]).searchParams.get("state")
+}
+
 jest.mock("axios")
 
 function mockAxios() {
@@ -50,6 +56,75 @@ describe("GitHubOAuthFacility", () => {
         }
         expect(appStub({ controller: AuthController }))
             .rejects.toThrowError("Parameterized route is not supported on GitHub callback uri")
+    })
+
+    it("Should use default configuration", async () => {
+        process.env.PLUM_GITHUB_CLIENT_ID = "123"
+        process.env.PLUM_GITHUB_CLIENT_SECRET = "secret"
+        mockAxios()
+        const fn = jest.fn()
+        class AuthController {
+            @redirectUri("GitHub")
+            @route.get("/auth/github/callback")
+            callback(@bind.oAuthUser() user: OAuthUser) {
+                fn(user)
+            }
+        }
+        const app = await fixture(AuthController)
+            .set(new OAuthFacility())
+            .set(new GitHubOAuthFacility())
+            .initialize()
+        const request = await supertest.agent(app.callback())
+        const state = await getState(request)
+        await request.get(`/auth/github/callback?code=lorem&state=${state}`)
+            .expect(200)
+        const tokenCall: any[] = (axios.post as jest.Mock).mock.calls[0]
+        tokenCall[1].redirect_uri = tokenCall[1].redirect_uri.replace(/:[0-9]{4,5}/, "")
+        expect(tokenCall).toMatchSnapshot()
+    })
+
+    it("Should throw error when no clientId default configuration provided", async () => {
+        delete process.env.PLUM_GITHUB_CLIENT_ID
+        process.env.PLUM_GITHUB_CLIENT_SECRET = "secret"
+        const fn = jest.fn()
+        try {
+            class AuthController {
+                @redirectUri("GitHub")
+                @route.get("/auth/github/callback")
+                callback(@bind.oAuthUser() user: OAuthUser) {
+                }
+            }
+            await fixture(AuthController)
+                .set(new OAuthFacility())
+                .set(new GitHubOAuthFacility())
+                .initialize()
+        }
+        catch (e) {
+            fn(e)
+        }
+        expect(fn.mock.calls).toMatchSnapshot()
+    })
+
+    it("Should throw error when no clientSecret default configuration provided", async () => {
+        process.env.PLUM_GITHUB_CLIENT_ID = "1234"
+        delete process.env.PLUM_GITHUB_CLIENT_SECRET
+        const fn = jest.fn()
+        try {
+            class AuthController {
+                @redirectUri("GitHub")
+                @route.get("/auth/github/callback")
+                callback(@bind.oAuthUser() user: OAuthUser) {
+                }
+            }
+            await fixture(AuthController)
+                .set(new OAuthFacility())
+                .set(new GitHubOAuthFacility())
+                .initialize()
+        }
+        catch (e) {
+            fn(e)
+        }
+        expect(fn.mock.calls).toMatchSnapshot()
     })
 })
 
@@ -166,12 +241,6 @@ describe("Login Endpoint", () => {
 })
 
 describe("Redirect URI Handler", () => {
-    const getState = async (rqs: supertest.SuperTest<supertest.Test>) => {
-        await rqs.get("/auth/csrf-secret")
-        const resp = await rqs.get("/auth/github/login")
-        return new URL(resp.header["location"]).searchParams.get("state")
-    }
-
     it("Should handle redirection properly", async () => {
         mockAxios()
         const fn = jest.fn()

--- a/tests/social-login-web/gitlab.spec.ts
+++ b/tests/social-login-web/gitlab.spec.ts
@@ -23,6 +23,12 @@ function appStub(opt?: { controller?: Class, csrfEndPoint?: string, loginEndPoin
         .initialize()
 }
 
+const getState = async (rqs: supertest.SuperTest<supertest.Test>) => {
+    await rqs.get("/auth/csrf-secret")
+    const resp = await rqs.get("/auth/gitlab/login")
+    return new URL(resp.header["location"]).searchParams.get("state")
+}
+
 jest.mock("axios")
 
 function mockAxios() {
@@ -50,6 +56,75 @@ describe("GitLabOAuthFacility", () => {
         }
         expect(appStub({ controller: AuthController }))
             .rejects.toThrowError("Parameterized route is not supported on GitLab callback uri")
+    })
+
+    it("Should use default configuration", async () => {
+        process.env.PLUM_GITLAB_CLIENT_ID = "123"
+        process.env.PLUM_GITLAB_CLIENT_SECRET = "secret"
+        mockAxios()
+        const fn = jest.fn()
+        class AuthController {
+            @redirectUri("GitLab")
+            @route.get("/auth/gitlab/callback")
+            callback(@bind.oAuthUser() user: OAuthUser) {
+                fn(user)
+            }
+        }
+        const app = await fixture(AuthController)
+            .set(new OAuthFacility())
+            .set(new GitLabOAuthFacility())
+            .initialize()
+        const request = await supertest.agent(app.callback())
+        const state = await getState(request)
+        await request.get(`/auth/gitlab/callback?code=lorem&state=${state}`)
+            .expect(200)
+        const tokenCall: any[] = (axios.post as jest.Mock).mock.calls[0]
+        tokenCall[1].redirect_uri = tokenCall[1].redirect_uri.replace(/:[0-9]{4,5}/, "")
+        expect(tokenCall).toMatchSnapshot()
+    })
+
+    it("Should throw error when no clientId default configuration provided", async () => {
+        delete process.env.PLUM_GITLAB_CLIENT_ID
+        process.env.PLUM_GITLAB_CLIENT_SECRET = "secret"
+        const fn = jest.fn()
+        try {
+            class AuthController {
+                @redirectUri("GitLab")
+                @route.get("/auth/gitlab/callback")
+                callback(@bind.oAuthUser() user: OAuthUser) {
+                }
+            }
+            await fixture(AuthController)
+                .set(new OAuthFacility())
+                .set(new GitLabOAuthFacility())
+                .initialize()
+        }
+        catch (e) {
+            fn(e)
+        }
+        expect(fn.mock.calls).toMatchSnapshot()
+    })
+
+    it("Should throw error when no clientSecret default configuration provided", async () => {
+        process.env.PLUM_GITLAB_CLIENT_ID = "1234"
+        delete process.env.PLUM_GITLAB_CLIENT_SECRET
+        const fn = jest.fn()
+        try {
+            class AuthController {
+                @redirectUri("GitLab")
+                @route.get("/auth/gitlab/callback")
+                callback(@bind.oAuthUser() user: OAuthUser) {
+                }
+            }
+            await fixture(AuthController)
+                .set(new OAuthFacility())
+                .set(new GitLabOAuthFacility())
+                .initialize()
+        }
+        catch (e) {
+            fn(e)
+        }
+        expect(fn.mock.calls).toMatchSnapshot()
     })
 })
 
@@ -166,11 +241,6 @@ describe("Login Endpoint", () => {
 })
 
 describe("Redirect URI Handler", () => {
-    const getState = async (rqs: supertest.SuperTest<supertest.Test>) => {
-        await rqs.get("/auth/csrf-secret")
-        const resp = await rqs.get("/auth/gitlab/login")
-        return new URL(resp.header["location"]).searchParams.get("state")
-    }
 
     it("Should handle redirection properly", async () => {
         mockAxios()


### PR DESCRIPTION
## Default Configuration 
With this PR some Facility now automatically load default configuration from environment variable: 

| Facility                | Environment Variable                                     |
| ----------------------- | -------------------------------------------------------- |
| `MongooseFacility`      | `PLUM_MONGODB_URI`                                       |
| `JwtAuthFacility`       | `PLUM_JWT_SECRET`                                        |
| `FacebookOAuthFacility` | `PLUM_FACEBOOK_CLIENT_ID`  `PLUM_FACEBOOK_CLIENT_SECRET` |
| `GoogleOAuthFacility`   | `PLUM_GOOGLE_CLIENT_ID`    `PLUM_GOOGLE_CLIENT_SECRET`   |
| `GitHubOAuthFacility`   | `PLUM_GITHUB_CLIENT_ID`    `PLUM_GITHUB_CLIENT_SECRET`   |
| `GitLabOAuthFacility`   | `PLUM_GITLAB_CLIENT_ID`    `PLUM_GITLAB_CLIENT_SECRET`   |