### PR TITLE
feat: Add form file binding decorator

### DIFF
--- a/packages/core/src/decorator.bind.ts
+++ b/packages/core/src/decorator.bind.ts
@@ -106,6 +106,15 @@ export namespace bind {
     }
 
     /**
+     * Bind file upload into parameter
+     *    
+     *     method(@bind.file("file") cookie:FormFile){}
+     */
+    export function file(name: string) {
+        return bind.custom(ctx => (ctx.request as any).files?.[name])
+    }
+
+    /**
      * Bind custom part of Koa context into parameter
      * example:
      * 

--- a/packages/core/src/decorator.bind.ts
+++ b/packages/core/src/decorator.bind.ts
@@ -110,7 +110,7 @@ export namespace bind {
      *    
      *     method(@bind.file("file") cookie:FormFile){}
      */
-    export function file(name: string) {
+    export function formFile(name: string) {
         return bind.custom(ctx => (ctx.request as any).files?.[name])
     }
 

--- a/tests/binder/__snapshots__/binder.spec.ts.snap
+++ b/tests/binder/__snapshots__/binder.spec.ts.snap
@@ -23,3 +23,18 @@ Object {
   "type": "image/jpeg",
 }
 `;
+
+exports[`Parameter Binding File parameter binding Should able to bind file using decorator 1`] = `
+Object {
+  "name": "clock.jpeg",
+  "type": "image/jpeg",
+}
+`;
+
+exports[`Parameter Binding File parameter binding Should not error when provided file binder decorator but provided no files 1`] = `
+Array [
+  Array [
+    undefined,
+  ],
+]
+`;

--- a/tests/binder/binder.spec.ts
+++ b/tests/binder/binder.spec.ts
@@ -1135,6 +1135,35 @@ describe("Parameter Binding", () => {
             expect(body).toMatchSnapshot()
         })
 
+        it("Should able to bind file using decorator", async () => {
+            class AnimalController {
+                @route.post()
+                save(@bind.file("file") data: FormFile) {
+                    return { name: data.name, type: data.type }
+                }
+            }
+            const { body } = await Supertest((await createApp(AnimalController)).callback())
+                .post("/animal/save")
+                .attach("file", join(__dirname, "./files/clock.jpeg"))
+                .expect(200)
+            expect(body).toMatchSnapshot()
+        })
+
+        it("Should not error when provided file binder decorator but provided no files", async () => {
+            const fn = jest.fn()
+            class AnimalController {
+                @route.post()
+                save(@bind.file("file") data: FormFile) {
+                    fn(data)
+                }
+            }
+            await Supertest((await createApp(AnimalController)).callback())
+                .post("/animal/save")
+                .expect(200)
+            expect(fn).toBeCalled()
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+
         it("Should able to bind array of files", async () => {
             class AnimalController {
                 @route.post()

--- a/tests/binder/binder.spec.ts
+++ b/tests/binder/binder.spec.ts
@@ -1138,7 +1138,7 @@ describe("Parameter Binding", () => {
         it("Should able to bind file using decorator", async () => {
             class AnimalController {
                 @route.post()
-                save(@bind.file("file") data: FormFile) {
+                save(@bind.formFile("file") data: FormFile) {
                     return { name: data.name, type: data.type }
                 }
             }
@@ -1153,7 +1153,7 @@ describe("Parameter Binding", () => {
             const fn = jest.fn()
             class AnimalController {
                 @route.post()
-                save(@bind.file("file") data: FormFile) {
+                save(@bind.formFile("file") data: FormFile) {
                     fn(data)
                 }
             }

--- a/tests/validation/__snapshots__/validation.spec.ts.snap
+++ b/tests/validation/__snapshots__/validation.spec.ts.snap
@@ -452,6 +452,22 @@ Object {
 }
 `;
 
+exports[`File Validation Should able to validate file size with file binding decorator 1`] = `
+Object {
+  "message": Array [
+    Object {
+      "messages": Array [
+        "File size exceed the limit allowed",
+      ],
+      "path": Array [
+        "data",
+      ],
+    },
+  ],
+  "status": 422,
+}
+`;
+
 exports[`File Validation Should able to validate mime type 1`] = `
 Object {
   "message": Array [

--- a/tests/validation/validation.spec.ts
+++ b/tests/validation/validation.spec.ts
@@ -1,4 +1,4 @@
-import { DefaultDependencyResolver, CustomValidatorFunction, FormFile, Class } from "@plumier/core"
+import { DefaultDependencyResolver, CustomValidatorFunction, FormFile, Class, bind } from "@plumier/core"
 import Plumier, {
     AsyncValidatorResult,
     CustomValidator,
@@ -692,6 +692,20 @@ describe("File Validation", () => {
             .post("/animal/save")
             .attach("file", join(__dirname, "./assets/dice.png"))
             .expect(200)
+        const { body } = await Supertest((await createApp(AnimalController)).callback())
+            .post("/animal/save")
+            .attach("file", join(__dirname, "./assets/big-image.jpg"))
+            .expect(422)
+        expect(body).toMatchSnapshot()
+    })
+
+    it("Should able to validate file size with file binding decorator", async () => {
+        class AnimalController {
+            @route.post()
+            save(@val.file("2Mb") @bind.formFile("file") data: FormFile) {
+                return { name: data.name, type: data.type }
+            }
+        }
         const { body } = await Supertest((await createApp(AnimalController)).callback())
             .post("/animal/save")
             .attach("file", join(__dirname, "./assets/big-image.jpg"))


### PR DESCRIPTION
## Form File Binding Decorator
This PR added support binding FormFile using decorator via `@bind.formFile()` 

```typescript
class AnimalController {
    @route.post()
    save(@bind.formFile("file") data: FormFile) {
        return { name: data.name, type: data.type }
    }
}
```