### PR TITLE
fix: Multiple FormFile issue with guestArrayElement

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,9 +24,9 @@
     "chalk": "^3.0.0",
     "glob": "^7.1.6",
     "path-to-regexp": "^6.1.0",
-    "tinspector": "^2.2.9",
+    "tinspector": "^2.2.10",
     "tslib": "^1.10.0",
-    "typedconverter": "^2.1.0"
+    "typedconverter": "^2.2.0"
   },
   "bugs": {
     "url": "https://github.com/plumier/plumier/issues"

--- a/packages/core/src/route-analyzer.ts
+++ b/packages/core/src/route-analyzer.ts
@@ -42,7 +42,7 @@ function traverseArray(parent: string, par: PropOrParamReflection[]): string[] {
       return models.map((x, i) => traverseArray(x.meta.name, x.meta.properties))
          .flatten()
    }
-   return par.filter(x => x.type === Array)
+   return par.filter(x => Array.isArray(x.type) && x.type[0] === Object)
       .map(x => `${parent}.${x.name}`)
 }
 

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -91,7 +91,7 @@ function validateSync(ctx: ActionContext, visitors: tc.VisitorExtension[]): Vali
         const rawParameter = ctx.parameters[index]
         const parValue = tc.validate(rawParameter, {
             decorators: parMeta.decorators, path: parMeta.name, type: parMeta.type || Object,
-            visitors, guessArrayElement: !!ctx.is("urlencoded")
+            visitors, guessArrayElement: !!ctx.is("urlencoded") || !!ctx.is("multipart")
         })
         result.push(parValue.value)
         if (parValue.issues)

--- a/packages/mongoose/src/index.ts
+++ b/packages/mongoose/src/index.ts
@@ -85,7 +85,7 @@ function generateSchema(opt: Class[], registry: SchemaRegistry, generator?: Sche
 
 function noArrayTypeInfoTest(domain: ClassReflection): AnalysisResult[] {
     return domain.properties
-        .map(x => (x.type === Array) ?
+        .map(x => (Array.isArray(x.type) && x.type[0] === Object) ?
             <AnalysisResult>{ message: ArrayHasNoTypeInfo.format(domain.name, x.name), type: "error" } : undefined)
         .filter((x): x is AnalysisResult => Boolean(x))
 }

--- a/tests/binder/__snapshots__/binder.spec.ts.snap
+++ b/tests/binder/__snapshots__/binder.spec.ts.snap
@@ -31,6 +31,15 @@ Object {
 }
 `;
 
+exports[`Parameter Binding File parameter binding Should not error when provided array of files but received single file 1`] = `
+Array [
+  Object {
+    "name": "clock.jpeg",
+    "type": "image/jpeg",
+  },
+]
+`;
+
 exports[`Parameter Binding File parameter binding Should not error when provided file binder decorator but provided no files 1`] = `
 Array [
   Array [

--- a/tests/binder/binder.spec.ts
+++ b/tests/binder/binder.spec.ts
@@ -1179,6 +1179,20 @@ describe("Parameter Binding", () => {
                 .expect(200)
             expect((body as any[]).sort((a, b) => a.name < b.name ? 1 : a.name > b.name ? -1 : 0)).toMatchSnapshot()
         })
+
+        it("Should not error when provided array of files but received single file", async () => {
+            class AnimalController {
+                @route.post()
+                save(file: FormFile[]) {
+                    return file.map(f => ({ name: f.name, type: f.type }))
+                }
+            }
+            const { body } = await Supertest((await createApp(AnimalController)).callback())
+                .post("/animal/save")
+                .attach("file", join(__dirname, "./files/clock.jpeg"))
+                .expect(200)
+            expect(body).toMatchSnapshot()
+        })
     })
 })
 


### PR DESCRIPTION
## Fix Bug: File Input with Multiple Property May Cause Error
An input file set with `multiple` property required the appropriate bound parameter uses Array of `FormFile`. This run well when number of files sent more than one, but cause problem when only single file sent. 

```html
<form method="POST" enctype="multipart/form-data" action="/animal/save">
    <input type="file" name="file" value="Select file" multiple/>
    <input type="submit" value="Upload"/>
</form>
```

The appropriate action:

```typescript
export class AnimalController {
    @route.post()
    save(file: FormFile[]) {
        return response.redirect("/")
    }
}
```

Above code will not working when only single file sent to server. This issue caused by `tinspector` module failed parse the type information of the Array parameter if no type override provided. 