### PR TITLE
fix: Fix array of FileForm causes route analysis warning

### DIFF
--- a/tests/binder/__snapshots__/binder.spec.ts.snap
+++ b/tests/binder/__snapshots__/binder.spec.ts.snap
@@ -31,6 +31,16 @@ Object {
 }
 `;
 
+exports[`Parameter Binding File parameter binding Should able to instantiate FormFile without error 1`] = `
+FormFile {
+  "mtime": "2018-1-1",
+  "name": "file.jpg",
+  "path": "/docs/file.jpg",
+  "size": 200,
+  "type": "image/jpeg",
+}
+`;
+
 exports[`Parameter Binding File parameter binding Should not error when provided array of files but received single file 1`] = `
 Array [
   Object {


### PR DESCRIPTION
## Array of FileForm and Route Analysis Warning
This PR fixes issue when `FileForm` defined as array and causing Route Analysis complaining about parameter binding being skipped

```
warning PLUM1006: Parameter binding skipped because array field without @array() decorator found in (AnimalController.save.file)
```

This PR change `FileForm` as a class so it possible to override the array type to prevent the warning. 

```typescript
export class AnimalController {
    @route.post()
    save(@reflect.type([FormFile]) file: FormFile[]) {
        console.log(file.length)
        return response.redirect("/")
    }
}
```

