### PR TITLE
fix: Fix ActionResult to accept HttpCookie interface and Array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ packages/**/*.js.snap
 !test.js
 .docs
 .env
+social-login-test
 yarn.lock
 !packages/plumier/test/integration/mongoose/model/jsonly-domain.js
 website/translated_docs

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,5 +22,5 @@ export {
     Middleware, MiddlewareFunction, MiddlewareDecorator, MiddlewareUtil, PlumierApplication, PlumierConfiguration, RedirectActionResult,
     ActionContext, RouteInfo, RouteAnalyzerFunction, RouteAnalyzerIssue, ValidatorDecorator, CustomValidatorFunction,
     ValidatorContext, ValidationError, errorMessage, AsyncValidatorResult, DefaultDependencyResolver,
-    CustomMiddleware, CustomMiddlewareFunction, FormFile
+    CustomMiddleware, CustomMiddlewareFunction, FormFile, HttpCookie
 } from "./types";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,6 +17,10 @@ const copyFileAsync = promisify(copyFile)
 // --------------------------- ACTION RESULT --------------------------- //
 // --------------------------------------------------------------------- //
 
+export interface HttpCookie {
+    key: string, value?: string, option?: SetOption
+}
+
 export class ActionResult {
     headers: { [key: string]: string | string[] } = {}
     cookies: { key: string, value?: string, option?: SetOption }[] = []
@@ -36,8 +40,17 @@ export class ActionResult {
         return this
     }
 
-    setCookie(key: string, value?: string, option?: SetOption) {
-        this.cookies.push({ key, value, option })
+    setCookie(cookie: HttpCookie): this
+    setCookie(cookie: HttpCookie[]): this
+    setCookie(key: string, value?: string, option?: SetOption): this
+    setCookie(key: string | HttpCookie | HttpCookie[], value?: string, option?: SetOption) {
+        if (typeof key === "string")
+            this.cookies.push({ key, value, option })
+        else if (Array.isArray(key)) {
+            key.forEach(x => this.cookies.push(x))
+        }
+        else
+            this.cookies.push(key)
         return this
     }
 

--- a/packages/plumier/src/index.ts
+++ b/packages/plumier/src/index.ts
@@ -9,7 +9,7 @@ export {
     PlumierApplication, PlumierConfiguration, RequestPart, response, route, RouteInfo,
     val, validate, ValidatorContext, ValidatorMiddleware, rest, RestDecoratorImpl,
     RouteDecoratorImpl, CustomBinderFunction, CustomAuthorizerFunction, CustomAuthorizer,
-    AuthorizerContext, CustomMiddleware, CustomMiddlewareFunction, FormFile
+    AuthorizerContext, CustomMiddleware, CustomMiddlewareFunction, FormFile, HttpCookie
 } from "@plumier/core"
 export * from "./facility"
 import "./validator"

--- a/tests/action-result/action-result.spec.ts
+++ b/tests/action-result/action-result.spec.ts
@@ -128,6 +128,87 @@ describe("Redirect Action Result", () => {
             .get("/animal/check")
             .expect(200, { cookie: "lorem ipsum" })
     })
+
+    it("Should be able to set cookie object", async () => {
+        class AnimalController {
+            @route.get()
+            index() {
+                return response.json({})
+                    .setCookie({ key: "theName", value: "lorem ipsum" })
+            }
+        }
+        const plumier = await new Plumier()
+            .set(new RestfulApiFacility())
+            .set({ controller: AnimalController })
+            .set({ mode: "production" })
+            .initialize()
+        await supertest(plumier.callback())
+            .get("/animal/index")
+            .expect(200)
+            .expect((resp: supertest.Response) => {
+                expect(resp.get("Set-Cookie")[0]).toBe("theName=lorem ipsum; path=/; httponly")
+            })
+    })
+
+    it("Should be able to set array of cookie object", async () => {
+        class AnimalController {
+            @route.get()
+            index() {
+                return response.json({})
+                    .setCookie([
+                        { key: "theName", value: "lorem ipsum" },
+                        { key: "otherName", value: "lorem ipsum" }
+                    ])
+            }
+        }
+        const plumier = await new Plumier()
+            .set(new RestfulApiFacility())
+            .set({ controller: AnimalController })
+            .set({ mode: "production" })
+            .initialize()
+        await supertest(plumier.callback())
+            .get("/animal/index")
+            .expect(200)
+            .expect((resp: supertest.Response) => {
+                expect(resp.get("Set-Cookie")[0]).toBe("theName=lorem ipsum; path=/; httponly")
+                expect(resp.get("Set-Cookie")[1]).toBe("otherName=lorem ipsum; path=/; httponly")
+            })
+    })
+
+    it("Should be able to remove multiple cookies using array", async () => {
+        class AnimalController {
+            @route.get()
+            index() {
+                return response.json({})
+                    .setCookie([
+                        { key: "theName", value: "lorem ipsum" },
+                        { key: "otherName", value: "lorem ipsum" }
+                    ])
+            }
+            remove() {
+                return response.json({})
+                    .setCookie([
+                        { key: "theName" },
+                        { key: "otherName" }
+                    ])
+            }
+        }
+        const plumier = await new Plumier()
+            .set(new RestfulApiFacility())
+            .set({ controller: AnimalController })
+            .set({ mode: "production" })
+            .initialize()
+        await supertest(plumier.callback())
+            .get("/animal/index")
+            .expect(200)
+        await supertest(plumier.callback())
+            .get("/animal/remove")
+            .expect(200)
+            .expect((resp: supertest.Response) => {
+                expect(resp.get("Set-Cookie")[0]).toContain("expires")
+                expect(resp.get("Set-Cookie")[1]).toContain("expires")
+            })
+    })
 })
 
 describe("Action Result", () => {


### PR DESCRIPTION
## HttpCookie Interface
This PR fixes `ActionResult` method `setCookie` to accept a cookie object `HttpCookie` like below: 

```typescript
return ActionResult({})
    .setCookie({ key: "theName", value: "lorem ipsum" })
```

Its also possible to set array of `HttpCookie`

```typescript
return ActionResult({})
    .setCookie([
        { key: "theName", value: "lorem ipsum" },
        { key: "otherName", value: "lorem ipsum",  option: { sameSite: "lax" } }
    ])
```

Its also possible to remove cookies using multiple names

```typescript
return ActionResult({})
    .setCookie([
        { key: "theName" },
        { key: "otherName" }
    ])
```