### PR TITLE
feat: Add social media profile and access token parameter binding

### DIFF
--- a/docs/refs/Social-Login.md
+++ b/docs/refs/Social-Login.md
@@ -115,6 +115,27 @@ Above is a common Plumier controller, no special configuration added except the 
 
 Controller above handles `GET /auth/callback` route, you can change this easily to match your redirect uri registered in the OAuth application provider. 
 
+## Parameter Binding
+Plumier provided several parameter binding to bind social media login data into callback uri methods.
+
+| Decorator | Description |
+| - | - |
+| `@bind.oAuthUser()` | Bind generalized social media login user of type `OAuthUser` |
+| `@bind.oAuthProfile()` | Bind the raw social media user profile | 
+| `@bind.oAuthToken()` | Bind social media auth token |
+
+To use it simply apply it in the method's parameter like below 
+
+```typescript
+class AuthController {
+    @route.get()
+    @redirectUri()
+    callback(@bind.oAuthUser() user:OAuthUser, @bind.oAuthProfile() profile:any, @bind.oAuthToken() token:string) {
+
+    }
+}
+```
+
 ## Separate Redirect Uris
 
 If you have different redirect uri registered on your OAuth application, you can create separate redirect uri for specific provider, while keep using the general redirect uri: 

--- a/tests/social-login/__snapshots__/oauth2.spec.ts.snap
+++ b/tests/social-login/__snapshots__/oauth2.spec.ts.snap
@@ -72,6 +72,21 @@ Object {
 }
 `;
 
+exports[`OAuth 2.0 Functionalities Should able to bind the oauth access_token 1`] = `"secret"`;
+
+exports[`OAuth 2.0 Functionalities Should able to bind the raw profile 1`] = `
+Object {
+  "email": "Josianne_Bosco@gmail.com",
+  "family_name": "Erdman",
+  "given_name": "Greta",
+  "id": "54f483f9-9b50-4c15-b53f-46ece9e3e5f8",
+  "locale": "en",
+  "name": "I Ketut Manuel Auer",
+  "picture": "http://lorempixel.com/640/480",
+  "query": Object {},
+}
+`;
+
 exports[`OAuth 2.0 Functionalities Should able to distinguish global callback and specific callback 1`] = `
 Object {
   "profile": Object {

--- a/tests/social-login/oauth2.spec.ts
+++ b/tests/social-login/oauth2.spec.ts
@@ -180,6 +180,32 @@ describe("OAuth 2.0", () => {
             expect(profile.profile.replace(/var message = '(.*)';/, "").replace(portRegex, "")).toMatchSnapshot()
             servers.close()
         })
+
+        it("Should able to bind the raw profile", async () => {
+            class AuthController {
+                @redirectUri()
+                callback(@bind.oAuthProfile() user: any) {
+                    return user
+                }
+            }
+            const servers = await appStub(AuthController, opt, opt)
+            const profile = await login(`${servers.origin}/auth/mazebook/login`)
+            expect(profile.profile).toMatchSnapshot()
+            servers.close()
+        })
+
+        it("Should able to bind the oauth access_token", async () => {
+            class AuthController {
+                @redirectUri()
+                callback(@bind.oAuthToken() token: string) {
+                    return token
+                }
+            }
+            const servers = await appStub(AuthController, opt, opt)
+            const profile = await login(`${servers.origin}/auth/mazebook/login`)
+            expect(profile.profile).toMatchSnapshot()
+            servers.close()
+        })
     })
 
     describe("Durability", () => {


### PR DESCRIPTION
This PR adds 2 more parameter binding to bind social media login data. 

| Decorator | Description |
| - | - |
| `@bind.oAuthUser()` | Bind generalized social media login user of type `OAuthUser` |
| `@bind.oAuthProfile()` | Bind the raw social media user profile | 
| `@bind.oAuthToken()` | Bind social media auth token |