### PR TITLE
feat: Add listen method to listen port form Plumier instance

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,6 +10,7 @@ import { domain } from './decorator'
 import { join, extname } from "path"
 import { copyFile, createReadStream } from 'fs'
 import { promisify } from "util"
+import { Server } from "http"
 
 const copyFileAsync = promisify(copyFile)
 
@@ -285,6 +286,14 @@ export interface Application {
     ```
      */
     initialize(): Promise<Koa>
+
+
+    /**
+     * Initialize Plumier and listen immediately to port. 
+     * Check for env variable named PLUM_PORT or listen to 8000
+     * @param port http port
+     */
+    listen(port?: number): Promise<Server>
 }
 
 export interface PlumierApplication extends Application {

--- a/packages/plumier/src/application.ts
+++ b/packages/plumier/src/application.ts
@@ -74,4 +74,12 @@ export class Plumier implements PlumierApplication {
             throw e
         }
     }
+
+    async listen(port = 8000) {
+        const app = await this.initialize()
+        const envPort = process.env.PLUM_PORT ? parseInt(process.env.PLUM_PORT) : port
+        if (this.config.mode === "debug")
+            console.log(`Server ready http://localhost:${envPort}/`)
+        return app.listen(envPort)
+    }
 }

--- a/tests/application/__snapshots__/basic.spec.ts.snap
+++ b/tests/application/__snapshots__/basic.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Listen Should show server info when in debug mode 1`] = `"Server ready http://localhost/"`;


### PR DESCRIPTION
## Listen Method
This PR add `listen` method to easily listen to port without having to us `Koa` instance. 

```typescript
new Plumier()
   .use(new WebApiFacility())
   .listen()
```

`listen` method accepts port value such as `listen(8080)` but first it will check for environment variable `PLUM_PORT`. 
