### PR TITLE
fix: Add configuration to accept proxy headers

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,6 +10,7 @@ import { domain } from './decorator'
 import { join, extname } from "path"
 import { copyFile, createReadStream } from 'fs'
 import { promisify } from "util"
+import { Server } from "http"
 
 const copyFileAsync = promisify(copyFile)
 
@@ -285,6 +286,14 @@ export interface Application {
     ```
      */
     initialize(): Promise<Koa>
+
+
+    /**
+     * Initialize Plumier and listen immediately to port. 
+     * Check for env variable named PLUM_PORT or listen to 8000
+     * @param port http port
+     */
+    listen(port?: number): Promise<Server>
 }
 
 export interface PlumierApplication extends Application {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -293,7 +293,7 @@ export interface Application {
      * Check for env variable named PLUM_PORT or listen to 8000
      * @param port http port
      */
-    listen(port?: number): Promise<Server>
+    listen(port?: number | string): Promise<Server>
 }
 
 export interface PlumierApplication extends Application {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -432,6 +432,12 @@ export interface Configuration {
      * Root directory of the application, usually __dirname
      */
     rootDir: string
+
+    /**
+     * Trust proxy headers such as X-Forwarded-For, X-Forwarded-Proto, X-Forwarded-Host and use its value 
+     * to appropriate request properties: ip, protocol, host
+     */
+    trustProxyHeader: boolean
 }
 
 export interface PlumierConfiguration extends Configuration {

--- a/packages/plumier/src/application.ts
+++ b/packages/plumier/src/application.ts
@@ -75,9 +75,16 @@ export class Plumier implements PlumierApplication {
         }
     }
 
-    async listen(port = 8000) {
+    async listen(port?: number | string) {
         const app = await this.initialize()
-        const envPort = process.env.PLUM_PORT ? parseInt(process.env.PLUM_PORT) : port
+        let envPort: number | undefined;
+        if(typeof port === "string"){
+            const result = parseInt(port)
+            if(isNaN(result)) throw Error(`Unable to parse port number ${port}. Please provide a valid integer number`)
+            envPort = result
+        }
+        else 
+            envPort = port
         if (this.config.mode === "debug")
             console.log(`Server ready http://localhost:${envPort}/`)
         return app.listen(envPort)

--- a/packages/plumier/src/application.ts
+++ b/packages/plumier/src/application.ts
@@ -33,7 +33,8 @@ export class Plumier implements PlumierApplication {
             facilities: [],
             roleField: "role",
             enableAuthorization: false,
-            rootDir: "__UNSET__"
+            rootDir: "__UNSET__", 
+            trustProxyHeader: false
         }
     }
 
@@ -68,6 +69,7 @@ export class Plumier implements PlumierApplication {
             }
             if (this.config.mode === "debug") printAnalysis(analyzeRoutes(routes, this.config))
             this.koa.use(router(routes, this.config))
+            this.koa.proxy = this.config.trustProxyHeader
             return this.koa
         }
         catch (e) {

--- a/packages/plumier/src/application.ts
+++ b/packages/plumier/src/application.ts
@@ -74,4 +74,12 @@ export class Plumier implements PlumierApplication {
             throw e
         }
     }
+
+    async listen(port = 8000) {
+        const app = await this.initialize()
+        const envPort = process.env.PLUM_PORT ? parseInt(process.env.PLUM_PORT) : port
+        if (this.config.mode === "debug")
+            console.log(`Server ready http://localhost:${envPort}/`)
+        return app.listen(envPort)
+    }
 }

--- a/packages/plumier/src/facility.ts
+++ b/packages/plumier/src/facility.ts
@@ -7,6 +7,7 @@ export interface WebApiFacilityOption {
     controller?: string | Class | Class[],
     bodyParser?: BodyParser.IKoaBodyOptions,
     cors?: Cors.Options | boolean,
+    trustProxyHeader?: boolean
     dependencyResolver?: DependencyResolver
 }
 
@@ -28,13 +29,15 @@ export class WebApiFacility extends DefaultFacility {
         if (typeof option.cors !== "boolean" && option.cors) {
             app.koa.use(Cors(option.cors))
         }
-        else if(option.cors){
+        else if (option.cors) {
             app.koa.use(Cors())
         }
         if (option.dependencyResolver)
             app.set({ dependencyResolver: option.dependencyResolver })
         if (option.controller)
             app.set({ controller: option.controller })
+        if (option.trustProxyHeader)
+            app.set({ trustProxyHeader: option.trustProxyHeader })
     }
 }
 
@@ -55,4 +58,3 @@ export class RestfulApiFacility extends WebApiFacility {
         app.set({ responseStatus: { post: 201, put: 204, delete: 204 } })
     }
 }
-

--- a/tests/application/__snapshots__/basic.spec.ts.snap
+++ b/tests/application/__snapshots__/basic.spec.ts.snap
@@ -1,3 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Listen Should show server info when in debug mode 1`] = `"Server ready http://localhost/"`;
+
+exports[`Listen Should throw error when provided invalid port number 1`] = `
+Array [
+  Array [
+    "Unable to parse port number INVALID NUMBER. Please provide a valid integer number",
+  ],
+]
+`;

--- a/tests/application/__snapshots__/basic.spec.ts.snap
+++ b/tests/application/__snapshots__/basic.spec.ts.snap
@@ -9,3 +9,15 @@ Array [
   ],
 ]
 `;
+
+exports[`Proxy Headers Should accept protocol when trusted 1`] = `
+Object {
+  "protocol": "https",
+}
+`;
+
+exports[`Proxy Headers Should not accept protocol by default 1`] = `
+Object {
+  "protocol": "http",
+}
+`;

--- a/tests/application/__snapshots__/basic.spec.ts.snap
+++ b/tests/application/__snapshots__/basic.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Listen Should show server info when in debug mode 1`] = `"Server ready http://localhost/"`;

--- a/tests/application/basic.spec.ts
+++ b/tests/application/basic.spec.ts
@@ -145,24 +145,33 @@ describe("Listen", () => {
         app.close()
     })
 
-    it("Should able to listen to env variable", async () => {
-        process.env.PLUM_PORT = (await getPort()).toString()
-        const app = await fixture().listen()
-        await Supertest(`http://localhost:${process.env.PLUM_PORT}`)
+    it("Should able to listen string port variable", async () => {
+        const port = await getPort()
+        const app = await fixture().listen(port.toString())
+        await Supertest(`http://localhost:${port}`)
             .get("/animal/get?id=123")
             .expect(200)
         app.close()
-        delete process.env.PLUM_PORT
+    })
+
+    it("Should throw error when provided invalid port number", async () => {
+        const fn = jest.fn()
+        try{
+            await fixture().listen("INVALID NUMBER")
+        }
+        catch(e){
+            fn(e.message)
+        }
+        expect(fn.mock.calls).toMatchSnapshot()
     })
 
     it("Should show server info when in debug mode", async () => {
         consoleLog.startMock()
-        process.env.PLUM_PORT = (await getPort()).toString()
-        const app = await fixture().set({mode: "debug"}).listen()
+        const port = (await getPort()).toString()
+        const app = await fixture().set({mode: "debug"}).listen(port)
         app.close()
         const mock = (console.log as jest.Mock)
         expect(mock.mock.calls[7][0].replace(/:[0-9]{4,5}/, "")).toMatchSnapshot()
-        delete process.env.PLUM_PORT
         consoleLog.clearMock()
     })
 })


### PR DESCRIPTION
## Proxy Headers (Heroku Issue)
When behind reverse proxy, some request information might forwarded in header information such as: 
* X-Forwarded-For : the request IP address 
* X-Forwarded-Proto: the request protocol
* X-Forwarded-Host: the request host
This issue occurs in some hostings such as Heroku. To fix this issue, the proxy header need to be configured (trusted).

```typescript
new Plumier()
.set(new WebApiFacility({ trustProxyHeader: true })
```
  