### PR TITLE
feat: Add force https

### DIFF
--- a/tests/application/__snapshots__/basic.spec.ts.snap
+++ b/tests/application/__snapshots__/basic.spec.ts.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Force HTTPS Should not redirect if in debug mode 1`] = `
+Array [
+  Array [
+    "Force HTTP disabled on debug mode",
+  ],
+]
+`;
+
+exports[`Force HTTPS Should redirect to https when enabled 1`] = `"https://127.0.0.1/animal/index"`;
+
 exports[`Listen Should show server info when in debug mode 1`] = `"Server ready http://localhost/"`;
 
 exports[`Listen Should throw error when provided invalid port number 1`] = `


### PR DESCRIPTION
## Force Https
This PR adds logic to redirect all HTTP request become HTTPS request. Enable this feature from `WebApiFacility` constructor.

Note that this feature only work when `NODE_ENV` set to production. 

```
new Plumier()
.set(new WebApiFacility({ forceHttps: true })
```