### PR TITLE
feat: Add rawBody parameter binding

### DIFF
--- a/packages/plumier/src/binder.ts
+++ b/packages/plumier/src/binder.ts
@@ -1,0 +1,25 @@
+
+import { bind } from "@plumier/core"
+
+const unparsed = Symbol.for('unparsedBody')
+
+declare module "@plumier/core" {
+    namespace bind {
+        /**
+         * Bind raw request body into parameter
+         * example:
+         * 
+         *    method(@bind.rawBody() data:any){}
+         * 
+         * **NOTE**: To use this functionality, the `includeUnparsed` need to be enabled on the WebApiFacility 
+         * 
+         *    new WebApiFacility({ bodyParser: { includeUnparsed:true } })
+         */
+        function rawBody(): (target: any, name: string, index: number) => void
+    }
+}
+
+bind.rawBody = () => {
+    return bind.custom(x => x.request.body[unparsed])
+}
+

--- a/packages/plumier/src/index.ts
+++ b/packages/plumier/src/index.ts
@@ -13,6 +13,7 @@ export {
 } from "@plumier/core"
 export * from "./facility"
 import "./validator"
+import "./binder"
 
 import { Plumier } from "./application"
 export default Plumier

--- a/tests/binder/binder.spec.ts
+++ b/tests/binder/binder.spec.ts
@@ -665,6 +665,39 @@ describe("Parameter Binding", () => {
         })
     })
 
+    describe("Request raw body parameter binding", () => {
+        @domain()
+        class AnimalModel {
+            constructor(
+                public id: number,
+                public name: string,
+                public deceased: boolean,
+                public birthday: Date
+            ) { }
+        }
+
+        function fixture(controller:Class){
+            return new Plumier()
+                .set({mode: "production"})
+                .set(new WebApiFacility({controller, bodyParser: { includeUnparsed:true }}))
+        }
+
+        it("Should bind raw body", async () => {
+            class AnimalController {
+                @route.post()
+                save(@bind.rawBody() b: any) {
+                    expect(typeof b).toBe("string")
+                    return b
+                }
+            }
+            await Supertest((await fixture(AnimalController).initialize()).callback())
+                .post("/animal/save")
+                .send({ id: "200", name: "Mimi", deceased: "ON", birthday: "2018-1-1" })
+                .expect(200)
+        })
+
+    })
+
     describe("Request header parameter binding", () => {
         it("Should bind request header", async () => {
             class AnimalController {


### PR DESCRIPTION
## Request Raw Body Binding
This PR adds feature to bind raw body into parameter. 

### Enable Functionality
By default this feature is disabled, enable this by set the `includeUnparsed` in the `WebApiFacility` configuration like below: 

```
new Plumier()
     .set(new WebApiFacility({ bodyParser: { includeUnparsed:true }}))
```

### Usage
Use it like other decorator based parameter binding like below

```
class AnimalController {
    @route.post()
    save(@bind.rawBody() body: any) {
        
    }
}
```