### PR TITLE
feat: Add function to register virtual route programmatically

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -94,6 +94,13 @@ export interface RouteInfo {
     access?: string
 }
 
+export interface VirtualRouteInfo {
+    className:string,
+    url:string,
+    method:HttpMethod,
+    access:string
+}
+
 
 export interface RouteAnalyzerIssue { type: "error" | "warning" | "success", message?: string }
 export type RouteAnalyzerFunction = (route: RouteInfo, allRoutes: RouteInfo[]) => RouteAnalyzerIssue
@@ -104,12 +111,12 @@ export type RouteAnalyzerFunction = (route: RouteInfo, allRoutes: RouteInfo[]) =
 
 export interface Facility {
     setup(app: Readonly<PlumierApplication>): void
-    initialize(app: Readonly<PlumierApplication>, routes: RouteInfo[]): Promise<void>
+    initialize(app: Readonly<PlumierApplication>, routes: RouteInfo[], vRoutes:VirtualRouteInfo[]): Promise<void>
 }
 
 export class DefaultFacility implements Facility {
     setup(app: Readonly<PlumierApplication>) { }
-    async initialize(app: Readonly<PlumierApplication>, routes: RouteInfo[]) { }
+    async initialize(app: Readonly<PlumierApplication>, routes: RouteInfo[], vRoutes:VirtualRouteInfo[]) { }
 }
 
 

--- a/packages/plumier/src/application.ts
+++ b/packages/plumier/src/application.ts
@@ -17,6 +17,7 @@ import {
 } from "@plumier/core"
 import Koa from "koa"
 import { dirname } from "path"
+import { VirtualRouteInfo } from 'core/src/types';
 
 
 
@@ -65,12 +66,13 @@ export class Plumier implements PlumierApplication {
             if (this.config.rootDir === "__UNSET__")
                 (this.config as Configuration).rootDir = dirname(module.parent!.parent!.filename)
             let routes: RouteInfo[] = generateRoutes(this.config.rootDir, this.config.controller)
+            const vRoutes: VirtualRouteInfo[] = []
             for (const facility of this.config.facilities) {
-                await facility.initialize(this, routes)
+                await facility.initialize(this, routes, vRoutes)
             }
             if (this.config.mode === "debug") {
                 printAnalysis(analyzeRoutes(routes, this.config))
-                printVirtualRoutes(this.config.middlewares, this.config.dependencyResolver)
+                printVirtualRoutes(vRoutes, this.config.middlewares, this.config.dependencyResolver)
             }
             this.koa.use(router(routes, this.config))
             this.koa.proxy = this.config.trustProxyHeader

--- a/tests/route-generator/__snapshots__/virtual-route.spec.ts.snap
+++ b/tests/route-generator/__snapshots__/virtual-route.spec.ts.snap
@@ -20,9 +20,6 @@ Array [
     "Virtual Routes",
   ],
   Array [
-    "These route might changed dynamically at runtime",
-  ],
-  Array [
     "1. MyMiddleware -> Public GET /route/route",
   ],
 ]
@@ -46,9 +43,6 @@ Array [
   Array [],
   Array [
     "Virtual Routes",
-  ],
-  Array [
-    "These route might changed dynamically at runtime",
   ],
   Array [
     "1. MyMiddleware -> Public GET /route/route",
@@ -76,9 +70,6 @@ Array [
     "Virtual Routes",
   ],
   Array [
-    "These route might changed dynamically at runtime",
-  ],
-  Array [
     "1. MyMiddleware -> Public GET /route/route",
   ],
 ]
@@ -104,10 +95,32 @@ Array [
     "Virtual Routes",
   ],
   Array [
-    "These route might changed dynamically at runtime",
+    "1. MyMiddleware -> Public GET /route/route",
+  ],
+]
+`;
+
+exports[`Virtual Route Should able register route programmatically 1`] = `
+Array [
+  Array [],
+  Array [
+    "Route Analysis Report",
   ],
   Array [
-    "1. MyMiddleware -> Public GET /route/route",
+    "1. AnimalController.get()   -> GET /animal/get",
+  ],
+  Array [
+    "2. BeastController.get()    -> GET /beast/get",
+  ],
+  Array [
+    "3. CreatureController.get() -> GET /creature/get",
+  ],
+  Array [],
+  Array [
+    "Virtual Routes",
+  ],
+  Array [
+    "1. MyFacility -> Public GET /route/route",
   ],
 ]
 `;
@@ -130,9 +143,6 @@ Array [
   Array [],
   Array [
     "Virtual Routes",
-  ],
-  Array [
-    "These route might changed dynamically at runtime",
   ],
   Array [
     "1. MyMiddleware -> Public GET /route/second-route",
@@ -161,9 +171,6 @@ Array [
   Array [],
   Array [
     "Virtual Routes",
-  ],
-  Array [
-    "These route might changed dynamically at runtime",
   ],
   Array [
     "1. MyMiddleware -> Public GET /route/route",

--- a/tests/route-generator/virtual-route.spec.ts
+++ b/tests/route-generator/virtual-route.spec.ts
@@ -1,7 +1,8 @@
 
 import Plumier, { route, CustomMiddleware, Invocation, ActionResult } from "plumier"
 import { Context } from "koa"
-import { consoleLog, DefaultFacility, PlumierApplication, DefaultDependencyResolver } from '@plumier/core'
+import { consoleLog, DefaultFacility, PlumierApplication, DefaultDependencyResolver, RouteInfo } from '@plumier/core'
+import { VirtualRouteInfo } from 'core/src/types'
 
 describe("Virtual Route", () => {
 
@@ -66,6 +67,20 @@ describe("Virtual Route", () => {
         class MyFacility extends DefaultFacility {
             async initialize(app: Readonly<PlumierApplication>) {
                 app.use(new MyMiddleware())
+            }
+        }
+        const mock = consoleLog.startMock()
+        await new Plumier()
+            .set(new MyFacility())
+            .initialize()
+        expect(mock.mock.calls).toMatchSnapshot()
+        consoleLog.clearMock()
+    })
+
+    it("Should able register route programmatically", async () => {
+        class MyFacility extends DefaultFacility {
+            async initialize(app: Readonly<PlumierApplication>, routes:RouteInfo[], vroutes:VirtualRouteInfo[]) {
+                vroutes.push({method: "get", url: "/route/route", access: "Public", className: "MyFacility"})
             }
         }
         const mock = consoleLog.startMock()


### PR DESCRIPTION
## Register Virtual Route Programmatically
This PR add function to register route programmatically from `Facility.initialize` method. 

```typescript
class MyFacility extends DefaultFacility {
    async initialize(app: Readonly<PlumierApplication>, routes:RouteInfo[], vroutes:VirtualRouteInfo[]) {
        vroutes.push({method: "get", url: "/route/route", access: "Public", className: "MyFacility"})
    }
}
```