### PR TITLE
feat: Expose metadata property to facilitate metaprogramming

### DIFF
--- a/docs/extends/Custom-Authorization.md
+++ b/docs/extends/Custom-Authorization.md
@@ -37,11 +37,11 @@ export class AnimalController {
 `AuthorizationContext` members is like below
 
 ```typescript
-export interface AuthorizationContext {
-    role: string[]
-    user:any
-    ctx: Koa.Context
+interface AuthorizationContext {
     value?: any
+    role: string[]
+    user: any
+    ctx: ActionContext
 }
 ```
 

--- a/packages/core/src/authorization.ts
+++ b/packages/core/src/authorization.ts
@@ -2,7 +2,7 @@ import { ParameterReflection, PropertyReflection, reflect } from "tinspector"
 
 import { Class, hasKeyOf, isCustomClass } from "./common"
 import { HttpStatus } from "./http-status"
-import { ActionContext, ActionResult, Configuration, HttpStatusError, Invocation, Middleware, RouteInfo } from "./types"
+import { ActionContext, ActionResult, Configuration, HttpStatusError, Invocation, Middleware, RouteInfo, Metadata } from "./types"
 
 
 // --------------------------------------------------------------------- //
@@ -14,6 +14,7 @@ interface AuthorizationContext {
     role: string[]
     user: any
     ctx: ActionContext
+    metadata: Metadata
 }
 
 type AuthorizerFunction = (info: AuthorizationContext, location: "Class" | "Parameter" | "Method") => boolean | Promise<boolean>
@@ -159,7 +160,7 @@ async function checkAuthorize(ctx: ActionContext) {
         const { route, parameters, state, config } = ctx
         const decorator = getAuthorizeDecorators(route, config.globalAuthorizationDecorators)
         const userRoles = await getRole(state.user, config.roleField)
-        const info = <AuthorizationContext>{ role: userRoles, user: state.user, route, ctx }
+        const info = <AuthorizationContext>{ role: userRoles, user: state.user, route, ctx, metadata: new Metadata(ctx.parameters, ctx.route) }
         //check user access
         await checkUserAccessToRoute(decorator, info)
         //if ok check parameter access

--- a/packages/core/src/decorator.ts
+++ b/packages/core/src/decorator.ts
@@ -1,6 +1,6 @@
 import reflect, { decorate } from "tinspector"
 
-import { Middleware, MiddlewareDecorator, MiddlewareFunction } from "./types"
+import { Middleware, MiddlewareDecorator, MiddlewareFunction, ActionContext } from "./types"
 
 
 // --------------------------------------------------------------------- //
@@ -14,12 +14,12 @@ function domain() { return reflect.parameterProperties() }
 // --------------------------------------------------------------------- //
 
 namespace middleware {
-    export function use(middleware: MiddlewareFunction): (...args: any[]) => void
+    export function use(middleware: MiddlewareFunction<ActionContext>): (...args: any[]) => void
     export function use(middleware: Middleware): (...args: any[]) => void
     export function use(id: string): (...args: any[]) => void
     export function use(id: symbol): (...args: any[]) => void
-    export function use(...middleware: (string | symbol | MiddlewareFunction | Middleware)[]) {
-        const value: MiddlewareDecorator = { name: "Middleware", value: middleware }
+    export function use(...middleware: (string | symbol | MiddlewareFunction<ActionContext> | Middleware)[]) {
+        const value: MiddlewareDecorator = { name: "Middleware", value: middleware as any}
         return decorate(value, ["Class", "Method"])
     }
 }

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -13,6 +13,7 @@ import {
     ValidationError,
     ValidatorContext,
     ValidatorDecorator,
+    Metadata,
 } from "./types"
 
 
@@ -45,7 +46,7 @@ interface ValidationResult {
 // Furthermore async validation process doesn't need to do the traversal process because all the required data already provided
 
 const getName = (path: string) => path.indexOf(".") > -1 ? path.substring(path.lastIndexOf(".") + 1) : path
-const emptyObject = (obj:any) => Object.keys(obj).length === 0 && obj.constructor === Object
+const emptyObject = (obj: any) => Object.keys(obj).length === 0 && obj.constructor === Object
 
 //custom visitor extension to gather the CustomValidatorNode
 function customValidatorNodeVisitor(items: CustomValidatorNode[]) {
@@ -65,7 +66,7 @@ function customValidatorNodeVisitor(items: CustomValidatorNode[]) {
 
 async function validateNode(node: CustomValidatorNode, ctx: ActionContext): Promise<AsyncValidatorResult[]> {
     const name = getName(node.path)
-    const info: ValidatorContext = { ctx, name, parent: node.parent }
+    const info: ValidatorContext = { ctx, name, parent: node.parent, metadata: new Metadata(ctx.parameters, ctx.route) }
     if (node.value === undefined || node.value === null || emptyObject(node.value)) return []
     let validator: CustomValidator;
     if (typeof node.validator === "function")

--- a/tests/application/__snapshots__/metaprogramming.spec.ts.snap
+++ b/tests/application/__snapshots__/metaprogramming.spec.ts.snap
@@ -1,0 +1,721 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Metaprogramming Action Middleware Should able spread invocation object 1`] = `
+Array [
+  Array [
+    "AnimalController",
+  ],
+  Array [
+    "/animal/get?id=1234",
+  ],
+]
+`;
+
+exports[`Metaprogramming Action Middleware Should able to access metadata from action controller 1`] = `
+Array [
+  Array [
+    Metadata {
+      "access": undefined,
+      "action": Object {
+        "decorators": Array [],
+        "kind": "Method",
+        "name": "get",
+        "parameters": Array [
+          Object {
+            "decorators": Array [],
+            "kind": "Parameter",
+            "name": "id",
+            "properties": Object {},
+            "type": undefined,
+            "typeClassification": undefined,
+          },
+        ],
+        "returnType": undefined,
+        "typeClassification": undefined,
+      },
+      "actionParams": ParameterMetadata {
+        "parameters": Array [
+          "1234",
+        ],
+        "routeInfo": Object {
+          "action": Object {
+            "decorators": Array [],
+            "kind": "Method",
+            "name": "get",
+            "parameters": Array [
+              Object {
+                "decorators": Array [],
+                "kind": "Parameter",
+                "name": "id",
+                "properties": Object {},
+                "type": undefined,
+                "typeClassification": undefined,
+              },
+            ],
+            "returnType": undefined,
+            "typeClassification": undefined,
+          },
+          "controller": Object {
+            "ctor": Object {
+              "kind": "Constructor",
+              "name": "constructor",
+              "parameters": Array [],
+            },
+            "decorators": Array [
+              Object {
+                "name": "Middleware",
+                "value": Array [
+                  ,
+                ],
+                Symbol(tinspector:decoratorOption): Object {
+                  "allowMultiple": true,
+                  "inherit": true,
+                },
+              },
+            ],
+            "kind": "Class",
+            "methods": Array [
+              Object {
+                "decorators": Array [],
+                "kind": "Method",
+                "name": "get",
+                "parameters": Array [
+                  Object {
+                    "decorators": Array [],
+                    "kind": "Parameter",
+                    "name": "id",
+                    "properties": Object {},
+                    "type": undefined,
+                    "typeClassification": undefined,
+                  },
+                ],
+                "returnType": undefined,
+                "typeClassification": undefined,
+              },
+            ],
+            "name": "AnimalController",
+            "properties": Array [],
+            "type": AnimalController,
+            "typeClassification": "Class",
+          },
+          "method": "get",
+          "url": "/animal/get",
+        },
+      },
+      "controller": Object {
+        "ctor": Object {
+          "kind": "Constructor",
+          "name": "constructor",
+          "parameters": Array [],
+        },
+        "decorators": Array [
+          Object {
+            "name": "Middleware",
+            "value": Array [
+              ,
+            ],
+            Symbol(tinspector:decoratorOption): Object {
+              "allowMultiple": true,
+              "inherit": true,
+            },
+          },
+        ],
+        "kind": "Class",
+        "methods": Array [
+          Object {
+            "decorators": Array [],
+            "kind": "Method",
+            "name": "get",
+            "parameters": Array [
+              Object {
+                "decorators": Array [],
+                "kind": "Parameter",
+                "name": "id",
+                "properties": Object {},
+                "type": undefined,
+                "typeClassification": undefined,
+              },
+            ],
+            "returnType": undefined,
+            "typeClassification": undefined,
+          },
+        ],
+        "name": "AnimalController",
+        "properties": Array [],
+        "type": AnimalController,
+        "typeClassification": "Class",
+      },
+    },
+  ],
+]
+`;
+
+exports[`Metaprogramming Action Middleware Should able to get all parameter names 1`] = `
+Array [
+  Array [
+    Array [
+      "id",
+      "name",
+    ],
+  ],
+]
+`;
+
+exports[`Metaprogramming Action Middleware Should able to get all parameter values 1`] = `
+Array [
+  Array [
+    Array [
+      "1234",
+      "mimi",
+    ],
+  ],
+]
+`;
+
+exports[`Metaprogramming Action Middleware Should able to get check if has parameter 1`] = `
+Array [
+  Array [
+    true,
+  ],
+  Array [
+    false,
+  ],
+]
+`;
+
+exports[`Metaprogramming Action Middleware Should able to get parameter by name 1`] = `
+Array [
+  Array [
+    "1234",
+  ],
+]
+`;
+
+exports[`Metaprogramming Action Middleware Should able to get parameter by number 1`] = `
+Array [
+  Array [
+    "1234",
+  ],
+]
+`;
+
+exports[`Metaprogramming Action Middleware Should return undefined if provided wrong parameter name 1`] = `
+Array [
+  Array [
+    undefined,
+  ],
+]
+`;
+
+exports[`Metaprogramming Custom Authorizer Should able to access metadata from custom authorizer 1`] = `
+Array [
+  Array [
+    Metadata {
+      "access": undefined,
+      "action": Object {
+        "decorators": Array [
+          Object {
+            "authorize": customAuthorizer,
+            "location": "Method",
+            "tag": "Custom",
+            "type": "plumier-meta:authorize",
+            Symbol(tinspector:decoratorOption): Object {
+              "allowMultiple": true,
+              "inherit": true,
+            },
+          },
+          Object {
+            "method": "get",
+            "name": "Route",
+            "url": undefined,
+            Symbol(tinspector:decoratorOption): Object {
+              "allowMultiple": true,
+              "inherit": true,
+            },
+          },
+        ],
+        "kind": "Method",
+        "name": "get",
+        "parameters": Array [
+          Object {
+            "decorators": Array [],
+            "kind": "Parameter",
+            "name": "id",
+            "properties": Object {},
+            "type": Number,
+            "typeClassification": "Primitive",
+          },
+        ],
+        "returnType": undefined,
+        "typeClassification": undefined,
+      },
+      "actionParams": ParameterMetadata {
+        "parameters": Array [
+          1234,
+        ],
+        "routeInfo": Object {
+          "action": Object {
+            "decorators": Array [
+              Object {
+                "authorize": customAuthorizer,
+                "location": "Method",
+                "tag": "Custom",
+                "type": "plumier-meta:authorize",
+                Symbol(tinspector:decoratorOption): Object {
+                  "allowMultiple": true,
+                  "inherit": true,
+                },
+              },
+              Object {
+                "method": "get",
+                "name": "Route",
+                "url": undefined,
+                Symbol(tinspector:decoratorOption): Object {
+                  "allowMultiple": true,
+                  "inherit": true,
+                },
+              },
+            ],
+            "kind": "Method",
+            "name": "get",
+            "parameters": Array [
+              Object {
+                "decorators": Array [],
+                "kind": "Parameter",
+                "name": "id",
+                "properties": Object {},
+                "type": Number,
+                "typeClassification": "Primitive",
+              },
+            ],
+            "returnType": undefined,
+            "typeClassification": undefined,
+          },
+          "controller": Object {
+            "ctor": Object {
+              "kind": "Constructor",
+              "name": "constructor",
+              "parameters": Array [],
+            },
+            "decorators": Array [],
+            "kind": "Class",
+            "methods": Array [
+              Object {
+                "decorators": Array [
+                  Object {
+                    "authorize": customAuthorizer,
+                    "location": "Method",
+                    "tag": "Custom",
+                    "type": "plumier-meta:authorize",
+                    Symbol(tinspector:decoratorOption): Object {
+                      "allowMultiple": true,
+                      "inherit": true,
+                    },
+                  },
+                  Object {
+                    "method": "get",
+                    "name": "Route",
+                    "url": undefined,
+                    Symbol(tinspector:decoratorOption): Object {
+                      "allowMultiple": true,
+                      "inherit": true,
+                    },
+                  },
+                ],
+                "kind": "Method",
+                "name": "get",
+                "parameters": Array [
+                  Object {
+                    "decorators": Array [],
+                    "kind": "Parameter",
+                    "name": "id",
+                    "properties": Object {},
+                    "type": Number,
+                    "typeClassification": "Primitive",
+                  },
+                ],
+                "returnType": undefined,
+                "typeClassification": undefined,
+              },
+            ],
+            "name": "AnimalController",
+            "properties": Array [],
+            "type": AnimalController,
+            "typeClassification": "Class",
+          },
+          "method": "get",
+          "url": "/animal/get",
+        },
+      },
+      "controller": Object {
+        "ctor": Object {
+          "kind": "Constructor",
+          "name": "constructor",
+          "parameters": Array [],
+        },
+        "decorators": Array [],
+        "kind": "Class",
+        "methods": Array [
+          Object {
+            "decorators": Array [
+              Object {
+                "authorize": customAuthorizer,
+                "location": "Method",
+                "tag": "Custom",
+                "type": "plumier-meta:authorize",
+                Symbol(tinspector:decoratorOption): Object {
+                  "allowMultiple": true,
+                  "inherit": true,
+                },
+              },
+              Object {
+                "method": "get",
+                "name": "Route",
+                "url": undefined,
+                Symbol(tinspector:decoratorOption): Object {
+                  "allowMultiple": true,
+                  "inherit": true,
+                },
+              },
+            ],
+            "kind": "Method",
+            "name": "get",
+            "parameters": Array [
+              Object {
+                "decorators": Array [],
+                "kind": "Parameter",
+                "name": "id",
+                "properties": Object {},
+                "type": Number,
+                "typeClassification": "Primitive",
+              },
+            ],
+            "returnType": undefined,
+            "typeClassification": undefined,
+          },
+        ],
+        "name": "AnimalController",
+        "properties": Array [],
+        "type": AnimalController,
+        "typeClassification": "Class",
+      },
+    },
+  ],
+]
+`;
+
+exports[`Metaprogramming Custom Validator Should able to access metadata from custom validator 1`] = `
+Array [
+  Array [
+    Metadata {
+      "access": undefined,
+      "action": Object {
+        "decorators": Array [
+          Object {
+            "method": "get",
+            "name": "Route",
+            "url": undefined,
+            Symbol(tinspector:decoratorOption): Object {
+              "allowMultiple": true,
+              "inherit": true,
+            },
+          },
+        ],
+        "kind": "Method",
+        "name": "get",
+        "parameters": Array [
+          Object {
+            "decorators": Array [
+              Object {
+                "type": "ValidatorDecorator",
+                "validator": greaterThan18,
+                Symbol(tinspector:decoratorOption): Object {
+                  "allowMultiple": true,
+                  "inherit": true,
+                },
+              },
+            ],
+            "kind": "Parameter",
+            "name": "id",
+            "properties": Object {},
+            "type": Number,
+            "typeClassification": "Primitive",
+          },
+        ],
+        "returnType": undefined,
+        "typeClassification": undefined,
+      },
+      "actionParams": ParameterMetadata {
+        "parameters": Array [
+          "1234",
+        ],
+        "routeInfo": Object {
+          "action": Object {
+            "decorators": Array [
+              Object {
+                "method": "get",
+                "name": "Route",
+                "url": undefined,
+                Symbol(tinspector:decoratorOption): Object {
+                  "allowMultiple": true,
+                  "inherit": true,
+                },
+              },
+            ],
+            "kind": "Method",
+            "name": "get",
+            "parameters": Array [
+              Object {
+                "decorators": Array [
+                  Object {
+                    "type": "ValidatorDecorator",
+                    "validator": greaterThan18,
+                    Symbol(tinspector:decoratorOption): Object {
+                      "allowMultiple": true,
+                      "inherit": true,
+                    },
+                  },
+                ],
+                "kind": "Parameter",
+                "name": "id",
+                "properties": Object {},
+                "type": Number,
+                "typeClassification": "Primitive",
+              },
+            ],
+            "returnType": undefined,
+            "typeClassification": undefined,
+          },
+          "controller": Object {
+            "ctor": Object {
+              "kind": "Constructor",
+              "name": "constructor",
+              "parameters": Array [],
+            },
+            "decorators": Array [],
+            "kind": "Class",
+            "methods": Array [
+              Object {
+                "decorators": Array [
+                  Object {
+                    "method": "get",
+                    "name": "Route",
+                    "url": undefined,
+                    Symbol(tinspector:decoratorOption): Object {
+                      "allowMultiple": true,
+                      "inherit": true,
+                    },
+                  },
+                ],
+                "kind": "Method",
+                "name": "get",
+                "parameters": Array [
+                  Object {
+                    "decorators": Array [
+                      Object {
+                        "type": "ValidatorDecorator",
+                        "validator": greaterThan18,
+                        Symbol(tinspector:decoratorOption): Object {
+                          "allowMultiple": true,
+                          "inherit": true,
+                        },
+                      },
+                    ],
+                    "kind": "Parameter",
+                    "name": "id",
+                    "properties": Object {},
+                    "type": Number,
+                    "typeClassification": "Primitive",
+                  },
+                ],
+                "returnType": undefined,
+                "typeClassification": undefined,
+              },
+            ],
+            "name": "AnimalController",
+            "properties": Array [],
+            "type": AnimalController,
+            "typeClassification": "Class",
+          },
+          "method": "get",
+          "url": "/animal/get",
+        },
+      },
+      "controller": Object {
+        "ctor": Object {
+          "kind": "Constructor",
+          "name": "constructor",
+          "parameters": Array [],
+        },
+        "decorators": Array [],
+        "kind": "Class",
+        "methods": Array [
+          Object {
+            "decorators": Array [
+              Object {
+                "method": "get",
+                "name": "Route",
+                "url": undefined,
+                Symbol(tinspector:decoratorOption): Object {
+                  "allowMultiple": true,
+                  "inherit": true,
+                },
+              },
+            ],
+            "kind": "Method",
+            "name": "get",
+            "parameters": Array [
+              Object {
+                "decorators": Array [
+                  Object {
+                    "type": "ValidatorDecorator",
+                    "validator": greaterThan18,
+                    Symbol(tinspector:decoratorOption): Object {
+                      "allowMultiple": true,
+                      "inherit": true,
+                    },
+                  },
+                ],
+                "kind": "Parameter",
+                "name": "id",
+                "properties": Object {},
+                "type": Number,
+                "typeClassification": "Primitive",
+              },
+            ],
+            "returnType": undefined,
+            "typeClassification": undefined,
+          },
+        ],
+        "name": "AnimalController",
+        "properties": Array [],
+        "type": AnimalController,
+        "typeClassification": "Class",
+      },
+    },
+  ],
+]
+`;
+
+exports[`Metaprogramming Global Middleware Should able to access metadata from global middleware 1`] = `
+Array [
+  Array [
+    Metadata {
+      "access": undefined,
+      "action": Object {
+        "decorators": Array [],
+        "kind": "Method",
+        "name": "get",
+        "parameters": Array [
+          Object {
+            "decorators": Array [],
+            "kind": "Parameter",
+            "name": "id",
+            "properties": Object {},
+            "type": undefined,
+            "typeClassification": undefined,
+          },
+        ],
+        "returnType": undefined,
+        "typeClassification": undefined,
+      },
+      "actionParams": ParameterMetadata {
+        "parameters": undefined,
+        "routeInfo": Object {
+          "action": Object {
+            "decorators": Array [],
+            "kind": "Method",
+            "name": "get",
+            "parameters": Array [
+              Object {
+                "decorators": Array [],
+                "kind": "Parameter",
+                "name": "id",
+                "properties": Object {},
+                "type": undefined,
+                "typeClassification": undefined,
+              },
+            ],
+            "returnType": undefined,
+            "typeClassification": undefined,
+          },
+          "controller": Object {
+            "ctor": Object {
+              "kind": "Constructor",
+              "name": "constructor",
+              "parameters": Array [],
+            },
+            "decorators": Array [],
+            "kind": "Class",
+            "methods": Array [
+              Object {
+                "decorators": Array [],
+                "kind": "Method",
+                "name": "get",
+                "parameters": Array [
+                  Object {
+                    "decorators": Array [],
+                    "kind": "Parameter",
+                    "name": "id",
+                    "properties": Object {},
+                    "type": undefined,
+                    "typeClassification": undefined,
+                  },
+                ],
+                "returnType": undefined,
+                "typeClassification": undefined,
+              },
+            ],
+            "name": "AnimalController",
+            "properties": Array [],
+            "type": AnimalController,
+            "typeClassification": "Class",
+          },
+          "method": "get",
+          "url": "/animal/get",
+        },
+      },
+      "controller": Object {
+        "ctor": Object {
+          "kind": "Constructor",
+          "name": "constructor",
+          "parameters": Array [],
+        },
+        "decorators": Array [],
+        "kind": "Class",
+        "methods": Array [
+          Object {
+            "decorators": Array [],
+            "kind": "Method",
+            "name": "get",
+            "parameters": Array [
+              Object {
+                "decorators": Array [],
+                "kind": "Parameter",
+                "name": "id",
+                "properties": Object {},
+                "type": undefined,
+                "typeClassification": undefined,
+              },
+            ],
+            "returnType": undefined,
+            "typeClassification": undefined,
+          },
+        ],
+        "name": "AnimalController",
+        "properties": Array [],
+        "type": AnimalController,
+        "typeClassification": "Class",
+      },
+    },
+  ],
+]
+`;
+
+exports[`Metaprogramming Global Middleware Should return undefined if access virtual route 1`] = `
+Array [
+  Array [
+    undefined,
+  ],
+]
+`;

--- a/tests/application/metaprogramming.spec.ts
+++ b/tests/application/metaprogramming.spec.ts
@@ -1,0 +1,229 @@
+import { authorize, CustomAuthorizerFunction, CustomValidatorFunction, middleware, route, val, ActionResult } from "@plumier/core"
+import { JwtAuthFacility } from "@plumier/jwt"
+import { sign } from "jsonwebtoken"
+import supertest from "supertest"
+
+import { fixture } from "../helper"
+
+
+
+describe("Metaprogramming", () => {
+    describe("Global Middleware", () => {
+        it("Should able to access metadata from global middleware", async () => {
+            const fn = jest.fn()
+
+            class AnimalController {
+                get(id: string) { return { id } }
+            }
+            const app = await fixture(AnimalController)
+                .use(x => {
+                    fn(x.metadata)
+                    return x.proceed()
+                })
+                .initialize()
+            await supertest(app.callback())
+                .get("/animal/get?id=1234")
+                .expect(200, { id: "1234" })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+
+        it("Should return undefined if access virtual route", async () => {
+            const fn = jest.fn()
+            class AnimalController {
+                get(id: string) { return { id } }
+            }
+            const app = await fixture(AnimalController)
+                .use(x => {
+                    fn(x.metadata)
+                    return x.proceed()
+                })
+                .use(async x => {
+                    if(x.ctx.path === "/animal/got")
+                        return new ActionResult({id: "1234"})
+                    return x.proceed()
+                })
+                .initialize()
+            await supertest(app.callback())
+                .get("/animal/got")
+                .expect(200, { id: "1234" })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+    })
+
+    describe("Action Middleware", () => {
+        it("Should able to access metadata from action controller", async () => {
+            const fn = jest.fn()
+            @middleware.use(x => {
+                fn(x.metadata)
+                return x.proceed()
+            })
+            class AnimalController {
+                get(id: string) { return { id } }
+            }
+            const app = await fixture(AnimalController).initialize()
+            await supertest(app.callback())
+                .get("/animal/get?id=1234")
+                .expect(200, { id: "1234" })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+
+        it("Should able to get parameter by name", async () => {
+            const fn = jest.fn()
+            @middleware.use(x => {
+                fn(x.metadata.actionParams.get("id"))
+                return x.proceed()
+            })
+            class AnimalController {
+                get(id: string) { return { id } }
+            }
+            const app = await fixture(AnimalController).initialize()
+            await supertest(app.callback())
+                .get("/animal/get?id=1234")
+                .expect(200, { id: "1234" })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+
+        it("Should return undefined if provided wrong parameter name", async () => {
+            const fn = jest.fn()
+            @middleware.use(x => {
+                fn(x.metadata.actionParams.get("UserId"))
+                return x.proceed()
+            })
+            class AnimalController {
+                get(id: string) { return { id } }
+            }
+            const app = await fixture(AnimalController).initialize()
+            await supertest(app.callback())
+                .get("/animal/get?id=1234")
+                .expect(200, { id: "1234" })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+
+        it("Should able to get parameter by number", async () => {
+            const fn = jest.fn()
+            @middleware.use(x => {
+                fn(x.metadata.actionParams.get(0))
+                return x.proceed()
+            })
+            class AnimalController {
+                get(id: string) { return { id } }
+            }
+            const app = await fixture(AnimalController).initialize()
+            await supertest(app.callback())
+                .get("/animal/get?id=1234")
+                .expect(200, { id: "1234" })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+
+        it("Should able to get check if has parameter", async () => {
+            const fn = jest.fn()
+            @middleware.use(x => {
+                fn(x.metadata.actionParams.hasName("ID"))
+                fn(x.metadata.actionParams.hasName("UserID"))
+                return x.proceed()
+            })
+            class AnimalController {
+                get(id: string) { return { id } }
+            }
+            const app = await fixture(AnimalController).initialize()
+            await supertest(app.callback())
+                .get("/animal/get?id=1234")
+                .expect(200, { id: "1234" })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+
+        it("Should able to get all parameter names", async () => {
+            const fn = jest.fn()
+            @middleware.use(x => {
+                fn(x.metadata.actionParams.names())
+                return x.proceed()
+            })
+            class AnimalController {
+                get(id: string, name: string) { return { id, name } }
+            }
+            const app = await fixture(AnimalController).initialize()
+            await supertest(app.callback())
+                .get("/animal/get?id=1234&name=mimi")
+                .expect(200, { id: "1234", name: "mimi" })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+
+        it("Should able to get all parameter values", async () => {
+            const fn = jest.fn()
+            @middleware.use(x => {
+                fn(x.metadata.actionParams.values())
+                return x.proceed()
+            })
+            class AnimalController {
+                get(id: string, name: string) { return { id, name } }
+            }
+            const app = await fixture(AnimalController).initialize()
+            await supertest(app.callback())
+                .get("/animal/get?id=1234&name=mimi")
+                .expect(200, { id: "1234", name: "mimi" })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+
+        it("Should able spread invocation object", async () => {
+            const fn = jest.fn()
+            @middleware.use(({ ctx, metadata, proceed }) => {
+                fn(metadata?.controller.name)
+                fn(ctx.url)
+                return proceed()
+            })
+            class AnimalController {
+                get(id: string) { return { id } }
+            }
+            const app = await fixture(AnimalController).initialize()
+            await supertest(app.callback())
+                .get("/animal/get?id=1234")
+                .expect(200, { id: "1234" })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+    })
+
+    describe("Custom Validator", () => {
+        it("Should able to access metadata from custom validator", async () => {
+            const fn = jest.fn()
+            const greaterThan18: CustomValidatorFunction = (x, { metadata }) => {
+                fn(metadata)
+                return x < 18 ? "Not allowed" : undefined
+            }
+            class AnimalController {
+                @route.get()
+                get(@val.custom(greaterThan18) id: number) { return { id } }
+            }
+            const app = await fixture(AnimalController).initialize()
+            await supertest(app.callback())
+                .get("/animal/get?id=1234")
+                .expect(200, { id: 1234 })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+    })
+
+
+    describe("Custom Authorizer", () => {
+        it("Should able to access metadata from custom authorizer", async () => {
+            const secret = "secret"
+            const token = sign({ id: 123, role: "User" }, secret)
+            const fn = jest.fn()
+            const customAuthorizer: CustomAuthorizerFunction = ({ metadata }) => {
+                fn(metadata)
+                return true
+            }
+            class AnimalController {
+                @route.get()
+                @authorize.custom(customAuthorizer)
+                get(id: number) { return { id } }
+            }
+            const app = await fixture(AnimalController)
+                .set(new JwtAuthFacility({ secret }))
+                .initialize()
+            await supertest(app.callback())
+                .get("/animal/get?id=1234")
+                .set({ Authorization: `Bearer ${token}` })
+                .expect(200, { id: 1234 })
+            expect(fn.mock.calls).toMatchSnapshot()
+        })
+    })
+})

--- a/tests/middleware/__snapshots__/middleware.spec.ts.snap
+++ b/tests/middleware/__snapshots__/middleware.spec.ts.snap
@@ -15,3 +15,11 @@ Array [
   ],
 ]
 `;
+
+exports[`Middleware Global Middleware Should throw error if wrong id provided 1`] = `
+Array [
+  Array [
+    [Error: PLUM1009: Object with id ipsum not found in Object registry],
+  ],
+]
+`;

--- a/tests/middleware/middleware.spec.ts
+++ b/tests/middleware/middleware.spec.ts
@@ -149,8 +149,8 @@ describe("Middleware", () => {
                 .expect(200, "The Body")
         })
 
-
         it("Should throw error if wrong id provided", async () => {
+            const fn = jest.fn()
             @middleware.use(x => {
                 return x.proceed()
             })
@@ -164,9 +164,11 @@ describe("Middleware", () => {
                 .use(returnError)
                 .use("ipsum")
                 .initialize()
+            app.on("error", e => fn(e))
             await Supertest(app.callback())
                 .get("/animal/get")
-                .expect(500, "PLUM1009: Object with id ipsum not found in Object registry")
+                .expect(500)
+            expect(fn.mock.calls).toMatchSnapshot()
         })
 
         it("Should execute middleware in proper order", async () => {


### PR DESCRIPTION
## Request Metadata
Request metadata contains information about Controller & Action metadata useful for metaprogramming. 

Request metadata accessible from `Invocation`, `ValidationContext` and `AuthorizerContext`. 

```typescript
// Invocation
const customMiddleware:CustomMiddlewareFunction = ({ metadata, proceed }) => {
    if(metadata.controller.name === "AnimalController")
        return proceed()
    else 
        throw new HttpStatusError(404)
}

// ValidatorContext
const customValidation: CustomValidatorFunction = (val, { metadata }) => { 
    // process metadata
}

// AuthorizerContext
const customAuthorizer: CustomAuthorizerFunction = ({ metadata, ctx }) => {
    // process metadata
}
```