### PR TITLE
fix: Fix mongoose helper document type inference

### DIFF
--- a/docs/refs/Mongoose-Helper.md
+++ b/docs/refs/Mongoose-Helper.md
@@ -27,6 +27,8 @@ Plumier Mongoose Helper uses tinspector to extract type metadata on runtime. Cur
 
 ### Using Property Field 
 ```typescript
+import {collection } from "@plumier/mongoose"
+
 @collection()
 class Dummy {
     @collection.property()
@@ -48,7 +50,7 @@ This is the common model declaration when you are familiar with Nest.js or other
 ### Using TypeScript Parameter Properties
 
 ```typescript 
-import reflect from "tinspector"
+import {collection } from "@plumier/mongoose"
 
 @collection()
 class Dummy {
@@ -360,3 +362,30 @@ POST /animal/save
 payload:
 {name: "Mimi", images: ["507f191e810c19729de860ea", "507f191e810c19729de239ca"]}
 ```
+
+## Dockify
+`Dockify<T>` is an advanced TypeScript type, it converts all Property of `T` inherit from `Object` into mongoose `Document`. For example: 
+
+```typescript 
+class Child {
+    constructor(
+        public name:string
+    ){}
+}
+
+class Parent {
+    constructor(
+        public child:Child
+    ){}
+}
+
+let parent:Dockify<Parent>
+// child property converted into `Child & mongoose.Document` 
+// thus its possible access document properties/method like below
+parent.child._id
+parent.child.save()
+```
+
+`Dockify<T>` provide syntax sugar to access ref (populate) properties, while keep entity definition POJO (clean from Mongoose specific types). 
+
+> **CAVEAT**: Dockify will treat all properties with custom type as Document, thus for non ref (populate) property will keep inferred as `Document`. 

--- a/packages/mongoose/readme.md
+++ b/packages/mongoose/readme.md
@@ -9,8 +9,15 @@
 ![npm (latest)](https://img.shields.io/npm/v/plumier/latest)
 
 
+
 ## Description
 Plumier Mongoose Helper help you easily map your domain model and create Mongoose model using it. Helper automatically generate schema definition based on your domain model metadata.
+
+- [x] Pure POJO, used conditional type to increase type inference on nested documents.
+- [x] Same schema configuration used by mongoose
+- [x] Inheritance
+- [x] Field properties or parameter properties declaration
+- [x] Model analysis
 
 ```typescript
 import { model, collection } from "@plumier/mongoose"
@@ -85,7 +92,7 @@ This is the common model declaration when you are familiar with Nest.js or other
 ### Using TypeScript Parameter Properties
 
 ```typescript 
-import reflect from "tinspector"
+import { collection } from "@plumier/mongoose"
 
 @collection()
 class Dummy {
@@ -183,6 +190,10 @@ class Dummy {
 
 const ChildModel = model(Child)
 const DummyModel = model(Dummy)
+
+const dummy = await DummyModel.findById("").populate("child")
+// child inferred as Document, so its possible to call Document related props/methods
+dummy.child.id
 ```
 
 ### Configure Properties 
@@ -282,3 +293,54 @@ const DummyModel = model(Dummy, schema => {
 // calling next model will not require passing the hook
 const SecondDummyModel = model(Dummy)
 ```
+
+### Model Analysis 
+Mongoose helper has built-in model analysis contains information about model, configuration and their appropriate MongoDB collection, use it like below
+
+
+```typescript
+import { model, collection, printAnalysis, getAnalysis } from "@plumier/mongoose"
+
+@collection()
+class Dummy {
+    constructor(
+        public stringProp: string,
+        public numberProp: number,
+        public booleanProp: boolean,
+        public dateProp: Date
+    ) { }
+}
+const DummyModel = model(Dummy)
+
+// somewhere when your code starting
+printAnalysis(getAnalysis())
+```
+
+## Dockify
+`Dockify<T>` is an advanced TypeScript type, it converts all Property of `T` inherit from `Object` into mongoose `Document`. For example: 
+
+```typescript 
+class Child {
+    constructor(
+        public name:string
+    ){}
+}
+
+class Parent {
+    constructor(
+        public child:Child
+    ){}
+}
+
+let parent:Dockify<Parent>
+// child property converted into `Child & mongoose.Document` 
+// thus its possible access document properties/method like below
+parent.child._id
+parent.child.save()
+```
+
+`Dockify<T>` provide syntax sugar to access ref (populate) properties, while keep entity definition POJO (clean from Mongoose specific types). 
+
+> **CAVEAT**: Dockify will treat all properties with custom type as Document, thus for non ref (populate) property will keep inferred as `Document`. 
+
+

--- a/packages/mongoose/src/generator.ts
+++ b/packages/mongoose/src/generator.ts
@@ -1,20 +1,20 @@
-import { Class, isCustomClass, DefaultFacility, PlumierApplication } from "@plumier/core"
-import mongoose, { SchemaTypeOpts } from "mongoose"
-import reflect, { ClassReflection, decorateProperty, mergeDecorator, PropertyReflection } from "tinspector"
+import { Class, isCustomClass } from "@plumier/core"
+import mongoose from "mongoose"
+import reflect, { ClassReflection, PropertyReflection } from "tinspector"
 
+import { createAnalyzer } from "./analyzer"
 import {
+    ClassOptionDecorator,
+    Dockify,
+    GeneratorHook,
     ModelFactory,
     ModelGenerator,
+    ModelStore,
     NamedSchemaOption,
     PropertyOptionDecorator,
     RefDecorator,
     ReferenceTypeNotRegistered,
-    MongooseFacilityOption,
-    GeneratorHook,
-    ClassOptionDecorator,
-    ModelStore,
 } from "./types"
-import { createAnalyzer } from './analyzer'
 
 
 
@@ -64,7 +64,7 @@ function modelFactory(store: Map<Class, ModelStore>): ModelFactory {
     return <T>(type: new (...args: any) => T, opt?: string | GeneratorHook | NamedSchemaOption) => {
         const storedModel = store.get(type)
         if (storedModel) {
-            return mongoose.model<T & mongoose.Document>(storedModel.name)
+            return mongoose.model(storedModel.name)
         }
         else {
             const meta = reflect(type)
@@ -73,7 +73,7 @@ function modelFactory(store: Map<Class, ModelStore>): ModelFactory {
             const definition = getDefinition(type, store)
             const schema = new mongoose.Schema(definition, option)
             if(option.hook) option.hook(schema)
-            const mongooseModel = mongoose.model<T & mongoose.Document>(name, schema)
+            const mongooseModel = mongoose.model<Dockify<T>>(name, schema)
             store.set(type, { name, collectionName: mongooseModel.collection.name, definition, option })
             return mongooseModel
         }

--- a/packages/mongoose/src/types.ts
+++ b/packages/mongoose/src/types.ts
@@ -5,14 +5,21 @@ import { Class } from '@plumier/core'
 // ------------------------------- TYPES ------------------------------- //
 // --------------------------------------------------------------------- //
 
+type Dockify<T> = {
+    [K in keyof T]: T[K] extends Date ? Date :
+    T[K] extends any[] ? DockifyArray<T[K]> :
+    T[K] extends object ? Dockify<T[K]> : T[K]
+} & mongoose.Document
+type DockifyArray<T> = T extends Date[] ? Date[] :
+    T extends object[] ? Dockify<T[number]>[] : T
 type GeneratorHook = (schema: mongoose.Schema) => void
 type NamedSchemaOption = SchemaOptions & { hook?: GeneratorHook, proxy?: boolean, name?: string }
 type MongooseFacilityOption = { uri?: string }
-type ModelFactory = <T>(type: new (...args: any) => T, opt?: string | GeneratorHook | NamedSchemaOption) => mongoose.Model<T & mongoose.Document, {}>
+type ModelFactory = <T>(type: new (...args: any) => T, opt?: string | GeneratorHook | NamedSchemaOption) => mongoose.Model<Dockify<T>, {}>
 interface ClassOptionDecorator { name: "ClassOption", option: NamedSchemaOption }
 interface PropertyOptionDecorator { name: "PropertyOption", option?: SchemaTypeOpts<any> }
 interface RefDecorator { name: "MongooseRef" }
-interface ModelStore { name: string, collectionName:string, definition: any, option: NamedSchemaOption }
+interface ModelStore { name: string, collectionName: string, definition: any, option: NamedSchemaOption }
 interface AnalysisResult { name: string, collection: string, option: string, definition: string }
 interface ModelGenerator {
     model: ModelFactory
@@ -27,5 +34,6 @@ export {
     ModelFactory, PropertyOptionDecorator, RefDecorator,
     ModelGenerator, MongooseFacilityOption, ClassOptionDecorator,
     ReferenceTypeNotRegistered, CanNotValidateNonProperty,
-    GeneratorHook, ModelStore, AnalysisResult
+    GeneratorHook, ModelStore, AnalysisResult, Dockify , DockifyArray 
 }
+

--- a/tests/behavior/mongoose/__snapshots__/dockify.spec.ts.snap
+++ b/tests/behavior/mongoose/__snapshots__/dockify.spec.ts.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dockify Should convert nested array ref type 1`] = `
+Object {
+  "__v": 0,
+  "_id": "MONGODB UNIQUE ID",
+  "child": Array [
+    Object {
+      "__v": 0,
+      "_id": "MONGODB UNIQUE ID",
+      "stringProp": "string",
+    },
+  ],
+}
+`;
+
+exports[`Dockify Should convert nested nested array ref type 1`] = `
+Object {
+  "__v": 0,
+  "_id": "MONGODB UNIQUE ID",
+  "child": Array [
+    Object {
+      "__v": 0,
+      "_id": "MONGODB UNIQUE ID",
+      "child": Array [
+        Object {
+          "__v": 0,
+          "_id": "MONGODB UNIQUE ID",
+          "stringProp": "string",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`Dockify Should convert nested nested ref type 1`] = `
+Object {
+  "__v": 0,
+  "_id": "MONGODB UNIQUE ID",
+  "child": Object {
+    "__v": 0,
+    "_id": "MONGODB UNIQUE ID",
+    "child": Object {
+      "__v": 0,
+      "_id": "MONGODB UNIQUE ID",
+      "stringProp": "string",
+    },
+  },
+}
+`;
+
+exports[`Dockify Should convert nested ref type 1`] = `
+Object {
+  "__v": 0,
+  "_id": "MONGODB UNIQUE ID",
+  "child": Object {
+    "__v": 0,
+    "_id": "MONGODB UNIQUE ID",
+    "stringProp": "string",
+  },
+}
+`;
+
+exports[`Dockify Should convert nested type 1`] = `
+Object {
+  "__v": 0,
+  "_id": "MONGODB UNIQUE ID",
+  "child": Object {
+    "stringProp": "string",
+  },
+}
+`;
+
+exports[`Dockify Should not convert primitive types 1`] = `
+Object {
+  "__v": 0,
+  "_id": "MONGODB UNIQUE ID",
+  "booleanProp": true,
+  "dateProp": 2020-2-2,
+  "numberProp": 123,
+  "stringProp": "string",
+}
+`;

--- a/tests/behavior/mongoose/dockify.spec.ts
+++ b/tests/behavior/mongoose/dockify.spec.ts
@@ -1,0 +1,192 @@
+import { collection, generator } from "@plumier/mongoose";
+import mongoose from "mongoose"
+
+const dbUri = "mongodb://localhost:27017/test-data"
+
+describe("Dockify", () => {
+    beforeAll(async () => await mongoose.connect(dbUri))
+    afterAll(async () => await mongoose.disconnect())
+    beforeEach(() => {
+        mongoose.models = {}
+        mongoose.connection.models = {}
+    })
+
+    it("Should not convert primitive types", async () => {
+        const { model } = generator()
+        @collection()
+        class Dummy {
+            constructor(
+                public stringProp: string,
+                public numberProp: number,
+                public booleanProp: boolean,
+                public dateProp: Date,
+            ) { }
+        }
+        const DummyModel = model(Dummy)
+        const result = await DummyModel.create(<Dummy>{
+            stringProp: "string",
+            numberProp: 123,
+            booleanProp: true,
+            dateProp: new Date(Date.UTC(2020, 2, 2))
+        })
+        expect(result).toMatchSnapshot()
+    })
+
+    it("Should convert nested type", async () => {
+        const { model } = generator()
+
+        @collection()
+        class Child {
+            constructor(
+                public stringProp: string
+            ) { }
+        }
+        @collection()
+        class Dummy {
+            constructor(
+                public child: Child
+            ) { }
+        }
+        const DummyModel = model(Dummy)
+        const dummy = await DummyModel.create(<Dummy>{
+            child: { stringProp: "string" }
+        })
+        const result = await DummyModel.findById(dummy._id)
+        expect(result!.child.id).toBeUndefined()
+        expect(result).toMatchSnapshot()
+    })
+
+    it("Should convert nested ref type", async () => {
+        const { model } = generator()
+
+        @collection({ toObject: { virtuals: true } })
+        class Child {
+            constructor(
+                public stringProp: string
+            ) { }
+        }
+        @collection()
+        class Dummy {
+            constructor(
+                @collection.ref(Child)
+                public child: Child
+            ) { }
+        }
+        const ChildModel = model(Child)
+        const DummyModel = model(Dummy)
+        const child = await ChildModel.create(<Child>{ stringProp: "string" })
+        const dummy = await DummyModel.create(<Dummy>{
+            child: child._id
+        })
+        const result = await DummyModel.findById(dummy._id).populate("child")
+        expect(result!.child.id).toBe(child._id.toString())
+        expect(result).toMatchSnapshot()
+    })
+
+    it("Should convert nested nested ref type", async () => {
+        const { model } = generator()
+
+        @collection({ toObject: { virtuals: true } })
+        class GrandChild {
+            constructor(
+                public stringProp: string
+            ) { }
+        }
+        @collection({ toObject: { virtuals: true } })
+        class Child {
+            constructor(
+                @collection.ref(GrandChild)
+                public child: GrandChild
+            ) { }
+        }
+        @collection()
+        class Dummy {
+            constructor(
+                @collection.ref(Child)
+                public child: Child
+            ) { }
+        }
+        const GrandChildModel = model(GrandChild)
+        const ChildModel = model(Child)
+        const DummyModel = model(Dummy)
+        const grandChild = await GrandChildModel.create(<GrandChild>{ stringProp: "string" })
+        const child = await ChildModel.create(<Child>{ child: grandChild._id })
+        const dummy = await DummyModel.create(<Dummy>{ child: child._id })
+        const result = await DummyModel.findById(dummy._id).populate({
+            path: "child",
+            populate: {
+                path: "child"
+            }
+        })
+        expect(result!.child.id).toBe(child._id.toString())
+        expect(result!.child.child.id).toBe(grandChild._id.toString())
+        expect(result).toMatchSnapshot()
+    })
+
+    it("Should convert nested array ref type", async () => {
+        const { model } = generator()
+
+        @collection({ toObject: { virtuals: true } })
+        class Child {
+            constructor(
+                public stringProp: string
+            ) { }
+        }
+        @collection()
+        class Dummy {
+            constructor(
+                @collection.ref([Child])
+                public child: Child[]
+            ) { }
+        }
+        const ChildModel = model(Child)
+        const DummyModel = model(Dummy)
+        const child = await ChildModel.create(<Child>{ stringProp: "string" })
+        const dummy = await DummyModel.create(<Dummy>{
+            child: [child._id]
+        })
+        const result = await DummyModel.findById(dummy._id).populate("child")
+        expect(result!.child[0].id).toBe(child._id.toString())
+        expect(result).toMatchSnapshot()
+    })
+
+    it("Should convert nested nested array ref type", async () => {
+        const { model } = generator()
+
+        @collection({ toObject: { virtuals: true } })
+        class GrandChild {
+            constructor(
+                public stringProp: string
+            ) { }
+        }
+        @collection({ toObject: { virtuals: true } })
+        class Child {
+            constructor(
+                @collection.ref([GrandChild])
+                public child: GrandChild[]
+            ) { }
+        }
+        @collection()
+        class Dummy {
+            constructor(
+                @collection.ref([Child])
+                public child: Child[]
+            ) { }
+        }
+        const GrandChildModel = model(GrandChild)
+        const ChildModel = model(Child)
+        const DummyModel = model(Dummy)
+        const grandChild = await GrandChildModel.create(<GrandChild>{ stringProp: "string" })
+        const child = await ChildModel.create(<Child>{ child: [grandChild._id] })
+        const dummy = await DummyModel.create(<Dummy>{ child: [child._id] })
+        const result = await DummyModel.findById(dummy._id).populate({
+            path: "child",
+            populate: {
+                path: "child"
+            }
+        })
+        expect(result!.child[0].id).toBe(child._id.toString())
+        expect(result!.child[0].child[0].id).toBe(grandChild._id.toString())
+        expect(result).toMatchSnapshot()
+    })
+})

--- a/tests/behavior/mongoose/mongoose.spec.ts
+++ b/tests/behavior/mongoose/mongoose.spec.ts
@@ -13,7 +13,10 @@ const dbUri = "mongodb://localhost:27017/test-data"
 describe("Mongoose", () => {
     beforeAll(async () => await mongoose.connect(dbUri))
     afterAll(async () => await mongoose.disconnect())
-    beforeEach(() => mongoose.models = {})
+    beforeEach(() => {
+        mongoose.models = {}
+        mongoose.connection.models = {}
+    })
 
     describe("Schema Generation", () => {
         it("Should work with primitive data", async () => {


### PR DESCRIPTION
## Dockify
`Dockify<T>` is an advanced TypeScript type, it converts all Property of `T` inherit from `Object` into mongoose `Document`. For example: 

```typescript 
class Child {
    constructor(
        public name:string
    ){}
}

class Parent {
    constructor(
        public child:Child
    ){}
}

let parent:Dockify<Parent>
// child property converted into `Child & mongoose.Document` 
// thus its possible access document properties/method like below
parent.child._id
parent.child.save()
```

`Dockify<T>` provide syntax sugar to access ref (populate) properties, while keep entity definition POJO (clean from Mongoose specific types). 

> **CAVEAT**: Dockify will treat all properties with custom type as Document, thus for non ref (populate) property will keep inferred as `Document`. 